### PR TITLE
Use markdown output for levitate is-compatible action

### DIFF
--- a/is-compatible/action.yml
+++ b/is-compatible/action.yml
@@ -27,7 +27,7 @@ runs:
     - id: run-levitate
       run: |
         # RUN levitate is-compatible. Save the output to .levitate_output
-        npx --yes @grafana/levitate@latest is-compatible --path ${{ inputs.module }} --target ${{ inputs.targets }} | tee .levitate_output
+        npx --yes @grafana/levitate@latest is-compatible --path ${{ inputs.module }} --target ${{ inputs.targets }} --markdown | tee .levitate_output
         # Save the command exit code for latesr use
         CODE=${PIPESTATUS[0]}
         # Capture levitate output in an ENV variable


### PR DESCRIPTION
Adds the `--markdown` option to the levitate call to output a markdown friendly text that can be parsed by github comment's markdown
