### PR TITLE
Install pnpm in build-plugin if not present

### DIFF
--- a/build-plugin/pm.sh
+++ b/build-plugin/pm.sh
@@ -6,10 +6,19 @@ if [ "$1" = "" ]; then
 	exit 1
 fi
 
+install_pnpm_if_not_present() {
+    if ! command -v pnpm &> /dev/null
+    then
+        echo "pnpm could not be found, installing..."
+        npm install -g pnpm
+    fi
+}
+
 # Detect the package manager
 if [ -f yarn.lock ]; then
 	pm="yarn"
 elif [ -f pnpm-lock.yaml ]; then
+	install_pnpm_if_not_present
 	pm="pnpm"
 elif [ -f package-lock.json ]; then
 	pm="npm"


### PR DESCRIPTION
To avoid the action to fail, we add a check for `pnpm` before it's usage. If `pnpm` isn't available we install it.