### PR TITLE
Publish report: Add grafana version to link

### DIFF
--- a/publish-report/action.yml
+++ b/publish-report/action.yml
@@ -39,4 +39,4 @@ runs:
 
     - name: Write report link to summary
       shell: bash
-      run: echo '<a href="https://storage.googleapis.com/releng-pipeline-artifacts-dev/${{ github.event.repository.name }}/${{ github.event.number }}/Grafana-v${{ inputs.grafana-version }}/index.html">Browse the Playwright report</a>' >> $GITHUB_STEP_SUMMARY
+      run: echo '<a href="https://storage.googleapis.com/releng-pipeline-artifacts-dev/${{ github.event.repository.name }}/${{ github.event.number }}/Grafana-v${{ inputs.grafana-version }}/index.html">Browse the Playwright report for Grafana-v${{ inputs.grafana-version }}</a>' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The publish-report action drops a link to the report in the workflow summary. This PR adds Grafana version to the end of the link text, making it possible to use the action multiple times within the same job. 

![Screenshot 2024-04-11 at 16 19 44](https://github.com/grafana/plugin-actions/assets/2388950/d075d7da-9312-4d49-9cf5-b798225e498d)
