### PR TITLE
add `package-plugin` action

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build-plugin/LICENSE
+++ b/build-plugin/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/is-compatible/LICENSE
+++ b/is-compatible/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package-plugin/LICENSE
+++ b/package-plugin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/package-plugin/LICENSE
+++ b/package-plugin/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package-plugin/README.md
+++ b/package-plugin/README.md
@@ -37,29 +37,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: grafana/plugin-actions/package-plugin@main
+        id: 'package-plugin'
         with:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-
-      - name: Get plugin metadata
-        id: metadata
-        run: |
-          sudo apt-get install jq
-
-          export GRAFANA_PLUGIN_ID=$(cat src/plugin.json | jq -r .id)
-          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-main.zip
-
-          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
-          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
 
       - id: 'auth'
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
 
-      - name: 'move release to main'
-        run: mv ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
+      - name: 'rename versioned archive to main-archive'
+        run: mv ${{ steps.package-plugin.outputs.archive }} ${{ steps.package-plugin.outputs.plugin-id }}-main.zip
 
       - id: 'upload-to-gcs'
         name: 'Upload assets to main'

--- a/package-plugin/README.md
+++ b/package-plugin/README.md
@@ -22,7 +22,7 @@ This workflow will trigger on pushes to the `main` branch. Use this workflow if 
 To build, package and release in a single action use [build-plugin](https://github.com/grafana/plugin-actions/tree/main/build-plugin)
 
 ```yaml
-name: Package and upload main
+name: Package plugin and upload artifact
 
 on:
   workflow_dispatch:

--- a/package-plugin/README.md
+++ b/package-plugin/README.md
@@ -17,7 +17,9 @@ This GitHub Action automates the process of packaging Grafana plugins. It takes 
 
 ### Package and upload the plugin
 
-This workflow will trigger on pushes to the `main` branch. Since this is not a versioned tag, the `build-plugin` workflow will not execute release steps, such as creating a GitHub release. Make use of this workflow, if you want to provide built plugins directly from your `main` branch.
+This workflow will trigger on pushes to the `main` branch. Use this workflow if you want to build plugins from your `main` branch as artifacts without creating a release.
+
+To build, package and release in a single action use [build-plugin](https://github.com/grafana/plugin-actions/tree/main/build-plugin)
 
 ```yaml
 name: Package and upload main

--- a/package-plugin/README.md
+++ b/package-plugin/README.md
@@ -1,0 +1,74 @@
+# Package plugin action
+
+This GitHub Action automates the process of packaging Grafana plugins. It takes the source code of a Grafana plugin and transforms it into an archive file, preparing it for distribution.
+
+## Features
+
+- Builds Grafana plugin source code into an archive for distribution.
+- Supports signing the plugin if a Grafana access token policy is provided.
+
+## Usage
+
+- Add this workflow to your GitHub repository as in the example.
+- Set up the necessary environment variables and secrets, including the Grafana access token policy (if signing is desired).
+- The action will build the plugin and create an archive that can be used by further steps of your workflow.
+
+## Examples
+
+### Package and upload the plugin
+
+This workflow will trigger on pushes to the `main` branch. Since this is not a versioned tag, the `build-plugin` workflow will not execute release steps, such as creating a GitHub release. Make use of this workflow, if you want to provide built plugins directly from your `main` branch.
+
+```yaml
+name: Package and upload main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main # Run workflow on pushes to `main`
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: grafana/plugin-actions/package-plugin@main
+        with:
+          # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
+          # save the value in your repository secrets
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+
+      - name: Get plugin metadata
+        id: metadata
+        run: |
+          sudo apt-get install jq
+
+          export GRAFANA_PLUGIN_ID=$(cat src/plugin.json | jq -r .id)
+          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-main.zip
+
+          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
+          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ env.GCP_UPLOAD_ARTIFACTS_KEY }}
+
+      - name: 'move release to main'
+        run: mv ${{ steps.build-release.outputs.archive }} ${{ steps.metadata.outputs.archive }}
+
+      - id: 'upload-to-gcs'
+        name: 'Upload assets to main'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: ./
+          destination: 'your-bucket-name/'
+          glob: '*.zip'
+          parent: false
+```
+
+## Options
+
+- `policy_token`: Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -1,0 +1,119 @@
+name: "Grafana Package Plugin"
+description: "Packages a Grafana plugin"
+
+outputs:
+  archive:
+    description: "The path to the plugin archive (zip)."
+    value: ${{ steps.metadata.outputs.archive }}
+  archive-sha1sum:
+    description: "The path to the plugin archive sha1sum."
+    value: ${{ steps.metadata.outputs.archive-sha1sum }}
+
+inputs:
+  policy_token:
+    description: "Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token"
+    required: false
+    default: ""
+  go-version:
+    description: "Version of go"
+    required: false
+    default: "1.21"
+  node-version:
+    description: "Version of node"
+    required: false
+    default: "20"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "${{ inputs.node-version }}"
+
+    - name: Setup Go environment
+      uses: actions/setup-go@v5
+      with:
+        go-version: "${{ inputs.go-version }}"
+
+    - name: Install dependencies
+      run: ${{ github.action_path }}/pm.sh install
+      shell: bash
+
+    - name: Build and test frontend
+      run: ${{ github.action_path }}/pm.sh build
+      shell: bash
+
+    - name: Check for backend
+      id: check-for-backend
+      run: |
+        if [ -f "Magefile.go" ]
+        then
+          echo "has-backend=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Test backend
+      if: steps.check-for-backend.outputs.has-backend == 'true'
+      uses: magefile/mage-action@v3
+      with:
+        version: latest
+        args: coverage
+
+    - name: Build backend
+      if: steps.check-for-backend.outputs.has-backend == 'true'
+      uses: magefile/mage-action@v3
+      with:
+        version: latest
+        args: buildAll
+
+    - name: Warn missing Grafana access policy token
+      run: |
+        echo Please generate a Grafana access policy token: https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token
+        echo Once done please follow the instructions found here: https://github.com/${{github.repository}}/blob/main/README.md#using-github-actions-release-workflow
+      if: ${{ inputs.policy_token == '' }}
+      shell: bash
+
+    - name: Sign plugin
+      run: ${{ github.action_path }}/pm.sh sign
+      shell: bash
+      env:
+        GRAFANA_ACCESS_POLICY_TOKEN: ${{ inputs.policy_token }}
+        GRAFANA_API_KEY: ${{ inputs.grafana_token }}
+      if: ${{ inputs.policy_token != '' }}
+
+    - name: Get plugin metadata
+      id: metadata
+      run: |
+        sudo apt-get install jq
+
+        export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
+        export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
+        export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
+        export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
+        export GRAFANA_PLUGIN_ARTIFACT_SHA1SUM=${GRAFANA_PLUGIN_ARTIFACT}.sha1
+
+        echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
+        echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
+        echo "plugin-type=${GRAFANA_PLUGIN_TYPE}" >> $GITHUB_OUTPUT
+        echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+        echo "archive-sha1sum=${GRAFANA_PLUGIN_ARTIFACT_SHA1SUM}" >> $GITHUB_OUTPUT
+
+        echo "github-tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Package plugin
+      id: package-plugin
+      run: |
+        mv dist ${{ steps.metadata.outputs.plugin-id }}
+        zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+        sha1sum ${{ steps.metadata.outputs.archive }} | cut -f1 -d' ' > ${{ steps.metadata.outputs.archive-sha1sum }}
+      shell: bash
+
+    - name: Validate plugin
+      run: |
+        git clone https://github.com/grafana/plugin-validator
+        pushd ./plugin-validator/pkg/cmd/plugincheck2
+        go install
+        popd
+        plugincheck2 -config ./plugin-validator/config/default.yaml ${{ steps.metadata.outputs.archive }}
+      shell: bash

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -8,6 +8,9 @@ outputs:
   archive-sha1sum:
     description: "The path to the plugin archive sha1sum."
     value: ${{ steps.metadata.outputs.archive-sha1sum }}
+ plugin-id:
+    description: "The ID of the plugin."
+    value: ${{ steps.metadata.outputs.plugin-id }}
 
 inputs:
   policy_token:

--- a/package-plugin/pm.sh
+++ b/package-plugin/pm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Check if command argument is provided
+if [ "$1" = "" ]; then
+	echo "Please provide a command to run."
+	exit 1
+fi
+
+install_pnpm_if_not_present() {
+    if ! command -v pnpm &> /dev/null
+    then
+        echo "pnpm could not be found, installing..."
+        npm install -g pnpm
+    fi
+}
+
+# Detect the package manager
+if [ -f yarn.lock ]; then
+	pm="yarn"
+elif [ -f pnpm-lock.yaml ]; then
+	install_pnpm_if_not_present
+	pm="pnpm"
+elif [ -f package-lock.json ]; then
+	pm="npm"
+else
+	echo "No recognized package manager found in this project."
+	exit 1
+fi
+
+# Run the provided command with the detected package manager
+echo "Running '$1' with $pm..."
+if [ "$1" = "install" ]; then
+	"$pm" install
+else
+	"$pm" run "$1"
+fi

--- a/publish-report/LICENSE
+++ b/publish-report/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I think it would be good to be able to skip release steps in the `build-plugin` action. We'd like to use the action to build versions from `main`, that shouldn't trigger a GH release.