### PR TITLE
Feat: Support monorepos

### DIFF
--- a/bundle-size/pm.sh
+++ b/bundle-size/pm.sh
@@ -2,8 +2,8 @@
 
 # Check if command argument is provided
 if [ "$1" = "" ]; then
-	echo "Please provide a command to run."
-	exit 1
+    echo "Please provide a command to run."
+    exit 1
 fi
 
 install_pnpm_if_not_present() {
@@ -18,35 +18,35 @@ install_pnpm_if_not_present() {
 current_dir=$(pwd)
 cd $(git rev-parse --show-toplevel) # Navigate to the root of the git repository
 if [ -f yarn.lock ]; then
-	pm="yarn"
+    pm="yarn"
 elif [ -f package-lock.json ]; then
-	pm="npm"
+    pm="npm"
 elif [ -f pnpm-lock.yaml ]; then
-  install_pnpm_if_not_present
-  pm="pnpm"
+    install_pnpm_if_not_present
+    pm="pnpm"
 else
-  echo "No recognized package manager found in this project."
-	exit 1
+    echo "No recognized package manager found in this project."
+    exit 1
 fi
 cd $current_dir # Navigate back to the original directory
 
 # Detect the command to run build
 if [ "$pm" = "yarn" ]; then
-  pmb=("yarn" "build" "--profile" "--json" "pr-stats.json")
+    pmb=("yarn" "build" "--profile" "--json" "pr-stats.json")
 elif [ "$pm" = "npm" ]; then
-  pmb=("npm" "run" "build" "--" "--profile" "--json" "pr-stats.json")
+    pmb=("npm" "run" "build" "--" "--profile" "--json" "pr-stats.json")
 elif [ "$pm" = "pnpm" ]; then
-  install_pnpm_if_not_present
-  pmb=("pnpm" "build" "--profile" "--json" "pr-stats.json")
+    install_pnpm_if_not_present
+    pmb=("pnpm" "build" "--profile" "--json" "pr-stats.json")
 else
-  echo "No recognized package manager found in this project."
-	exit 1
+    echo "No recognized package manager found in this project."
+    exit 1
 fi
 
 # Run the provided command with the detected package manager
 echo "Running '$1' with $pm..."
 if [ "$1" = "install" ]; then
-	"$pm" install
+    "$pm" install
 elif [ "$1" = "build" ]; then
-	"${pmb[@]}"
+    "${pmb[@]}"
 fi

--- a/bundle-size/pm.sh
+++ b/bundle-size/pm.sh
@@ -15,25 +15,32 @@ install_pnpm_if_not_present() {
 }
 
 # Detect the package manager
+current_dir=$(pwd)
+cd $(git rev-parse --show-toplevel) # Navigate to the root of the git repository
 if [ -f yarn.lock ]; then
 	pm="yarn"
 elif [ -f package-lock.json ]; then
 	pm="npm"
+elif [ -f pnpm-lock.yaml ]; then
+  install_pnpm_if_not_present
+  pm="pnpm"
 else
-	echo "Defaulting to pnpm for install command."
-	install_pnpm_if_not_present
-	pm="pnpm"
+  echo "No recognized package manager found in this project."
+	exit 1
 fi
+cd $current_dir # Navigate back to the original directory
 
 # Detect the command to run build
-if [ -f yarn.lock ]; then
+if [ "$pm" = "yarn" ]; then
   pmb=("yarn" "build" "--profile" "--json" "pr-stats.json")
-elif [ -f package-lock.json ]; then
+elif [ "$pm" = "npm" ]; then
   pmb=("npm" "run" "build" "--" "--profile" "--json" "pr-stats.json")
-else
-  echo "Defaulting to pnpm for build command."
+elif [ "$pm" = "pnpm" ]; then
   install_pnpm_if_not_present
   pmb=("pnpm" "build" "--profile" "--json" "pr-stats.json")
+else
+  echo "No recognized package manager found in this project."
+	exit 1
 fi
 
 # Run the provided command with the detected package manager


### PR DESCRIPTION
Currently the bundle-size action defaults to PNPM if a package manager cannot be discovered when being run from within a monorepo. This works for an PNPM monorepo but will break for monorepos using yarn or npm. This PR addresses this issue by navigating to the root of the project before checking the lock files then switching back to the previous working directory.