### PR TITLE
Feat: Add optional parameter to select backend target architecture

### DIFF
--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -56,7 +56,7 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@add-options-to-select-backend-target-arch
+      uses: grafana/plugin-actions/package-plugin@main
       with:
         policy_token: ${{ inputs.policy_token }}
         node-version: "${{ inputs.node-version }}"

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -45,7 +45,7 @@ runs:
         policy_token: ${{ inputs.policy_token }}
         node-version: "${{ inputs.node-version }}"
         go-version: "${{ inputs.go-version }}"
-        backed-target: "${{ inputs.backend-target }}"
+        backend-target: "${{ inputs.backend-target }}"
 
     - name: Get plugin metadata
       id: metadata

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -31,7 +31,22 @@ inputs:
     required: false
     default: "20"
   backend-target:
-    description: "Backend target architecture for the plugin"
+    description: |
+      Backend target for the plugin backend build. Supported values:
+        build:backend
+        build:darwin
+        build:darwinARM64
+        build:debug
+        build:debugDarwinAMD64
+        build:debugDarwinARM64
+        build:debugLinuxAMD64
+        build:debugLinuxARM64
+        build:debugWindowsAMD64
+        build:linux
+        build:linuxARM
+        build:linuxARM64
+        build:windows
+        buildAll
     required: false
     default: "buildAll"
 

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -31,22 +31,23 @@ inputs:
     required: false
     default: "20"
   backend-target:
-    description: |
-      Backend target for the plugin backend build. Supported values:
-        build:backend
-        build:darwin
-        build:darwinARM64
-        build:debug
-        build:debugDarwinAMD64
-        build:debugDarwinARM64
-        build:debugLinuxAMD64
-        build:debugLinuxARM64
-        build:debugWindowsAMD64
-        build:linux
-        build:linuxARM
-        build:linuxARM64
-        build:windows
-        buildAll
+    type: choice
+    description: "Backend target for the plugin backend build"
+    options:
+        - build:backend
+        - build:darwin
+        - build:darwinARM64
+        - build:debug
+        - build:debugDarwinAMD64
+        - build:debugDarwinARM64
+        - build:debugLinuxAMD64
+        - build:debugLinuxARM64
+        - build:debugWindowsAMD64
+        - build:linux
+        - build:linuxARM
+        - build:linuxARM64
+        - build:windows
+        - buildAll
     required: false
     default: "buildAll"
 

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -40,11 +40,12 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@main
+      uses: grafana/plugin-actions/package-plugin@add-options-to-select-backend-target-arch
       with:
         policy_token: ${{ inputs.policy_token }}
         node-version: "${{ inputs.node-version }}"
         go-version: "${{ inputs.go-version }}"
+        backed-target: "${{ inputs.backend-target }}"
 
     - name: Get plugin metadata
       id: metadata

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
+  backend-target:
+    description: "Backend target architecture for the plugin"
+    required: false
+    default: "buildAll"
 
 runs:
   using: "composite"

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -29,7 +29,22 @@ inputs:
     required: false
     default: "20"
   backend-target:
-    description: "Backend target architecture for the plugin"
+    description: |
+      Backend target for the plugin backend build. Supported values:
+        build:backend
+        build:darwin
+        build:darwinARM64
+        build:debug
+        build:debugDarwinAMD64
+        build:debugDarwinARM64
+        build:debugLinuxAMD64
+        build:debugLinuxARM64
+        build:debugWindowsAMD64
+        build:linux
+        build:linuxARM
+        build:linuxARM64
+        build:windows
+        buildAll
     required: false
     default: "buildAll"
 

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -29,22 +29,23 @@ inputs:
     required: false
     default: "20"
   backend-target:
-    description: |
-      Backend target for the plugin backend build. Supported values:
-        build:backend
-        build:darwin
-        build:darwinARM64
-        build:debug
-        build:debugDarwinAMD64
-        build:debugDarwinARM64
-        build:debugLinuxAMD64
-        build:debugLinuxARM64
-        build:debugWindowsAMD64
-        build:linux
-        build:linuxARM
-        build:linuxARM64
-        build:windows
-        buildAll
+    type: choice
+    description: "Backend target for the plugin backend build"
+    options:
+        - build:backend
+        - build:darwin
+        - build:darwinARM64
+        - build:debug
+        - build:debugDarwinAMD64
+        - build:debugDarwinARM64
+        - build:debugLinuxAMD64
+        - build:debugLinuxARM64
+        - build:debugWindowsAMD64
+        - build:linux
+        - build:linuxARM
+        - build:linuxARM64
+        - build:windows
+        - buildAll
     required: false
     default: "buildAll"
 

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
+  backend-target:
+    description: "Backend target architecture for the plugin"
+    required: false
+    default: "buildAll"
 
 runs:
   using: "composite"
@@ -70,7 +74,7 @@ runs:
       uses: magefile/mage-action@v3
       with:
         version: latest
-        args: buildAll
+        args: "${{ inputs.backend-target }}"
 
     - name: Warn missing Grafana access policy token
       run: |


### PR DESCRIPTION
Add input `backend-target` to actions `build-plugin` and `package-plugin` to allow user to select the target architecture to build backend binary

## Note for reviewers
I've used the `type: choice` initially as an attempt to limit the input to only the values in option, but my tests showed that no errors are thrown when a different value is provided. I decided to let the `type: choice` and the options to document the possible values.