### PR TITLE
Add option to create package attestation for build verification

### DIFF
--- a/build-plugin/README.md
+++ b/build-plugin/README.md
@@ -92,7 +92,7 @@ jobs:
 
 - `policy_token`: Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token
 - `grafana_token`: [deprecated] Grafana API Key to sign a plugin. Prefer `policy_token`. See https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin
-- attestation: Create a verifiable attestation for the plugin using sigstore. See [attestation of plugin package](#attestation-of-plugin-package)
+- attestation: If `true`, create a verifiable attestation for the plugin using sigstore. See [attestation of plugin package](#attestation-of-plugin-package)
 
 ## Troubleshooting
 

--- a/build-plugin/README.md
+++ b/build-plugin/README.md
@@ -7,6 +7,7 @@ This GitHub Action automates the process of building Grafana plugins. It takes t
 - Builds Grafana plugin source code into an archive for distribution.
 - Generates a draft Github release for the plugin.
 - Supports signing the plugin if a Grafana access token policy is provided.
+- Supports creating a [signed build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds). This guarantees that the plugin was built from the source code provided in the release.
 
 ## Usage
 
@@ -28,12 +29,12 @@ on:
     tags:
       - "v*" # Run workflow on version tags, e.g. v1.0.0.
 
-# necessary to create releases
-permissions:
-  contents: write
-
 jobs:
   release:
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,9 +44,52 @@ jobs:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          # creates a signed build provenance attestation to verify the authenticity of the plugin build
+          attestation: true
+```
+
+## Attestation of plugin package
+
+If you pass `attestation: true` to the action, it will create a signed build provenance attestation for the plugin package using github [attest-build-provenance action](https://github.com/actions/attest-build-provenance).
+
+This attestation will be used to verify the authenticity of the plugin package build and ensure that the plugin was built from the source code provided in the release.
+
+### Add attestation to your existing workflow
+
+To add the attestation to your existing workflow, you can use the following steps:
+
+1. Add the `id-token: write` and `attestations: write` permissions to your workflow.
+2. Add the `attestation: true` option to the `build-plugin` action.
+
+e.g.
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*" # Run workflow on version tags, e.g. v1.0.0.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions: # new line
+      id-token: write # new line
+      contents: write # new line
+      attestations: write # new line
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: grafana/plugin-actions/build-plugin@main
+        with:
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          attestation: true # new line
 ```
 
 ## Options
 
 - `policy_token`: Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token
 - `grafana_token`: [deprecated] Grafana API Key to sign a plugin. Prefer `policy_token`. See https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin
+- attestation: Create a verifiable attestation for the plugin using sigstore. See [attestation of plugin package](#attestation-of-plugin-package)

--- a/build-plugin/README.md
+++ b/build-plugin/README.md
@@ -58,8 +58,8 @@ This attestation will be used to verify the authenticity of the plugin package b
 
 To add the attestation to your existing workflow, you can use the following steps:
 
-1. Add the `id-token: write` and `attestations: write` permissions to your workflow.
-2. Add the `attestation: true` option to the `build-plugin` action.
+1. Add the `id-token: write` and `attestations: write` permissions to your workflow job.
+1. Add the `attestation: true` option to the `build-plugin` action.
 
 e.g.
 
@@ -101,3 +101,13 @@ jobs:
 You are missing the `attestations: write` permission in your workflow.
 
 See [Add attestation to your existing workflow](#add-attestation-to-your-existing-workflow) for more information.
+
+### Error: Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
+
+You are missing the `id-token: write` permission in your workflow.
+
+See [Add attestation to your existing workflow](#add-attestation-to-your-existing-workflow) for more information.
+
+### Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
+
+You are missing the `contents: write` permission in your workflow.

--- a/build-plugin/README.md
+++ b/build-plugin/README.md
@@ -93,3 +93,11 @@ jobs:
 - `policy_token`: Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token
 - `grafana_token`: [deprecated] Grafana API Key to sign a plugin. Prefer `policy_token`. See https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin
 - attestation: Create a verifiable attestation for the plugin using sigstore. See [attestation of plugin package](#attestation-of-plugin-package)
+
+## Troubleshooting
+
+### Error: Failed to persist attestation: Resource not accessible by integration
+
+You are missing the `attestations: write` permission in your workflow.
+
+See [Add attestation to your existing workflow](#add-attestation-to-your-existing-workflow) for more information.

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -94,7 +94,7 @@ runs:
       shell: bash
 
     - name: Generate artifact attestation
-      if: ${{ inputs.attestation == 'true' }}
+      if: ${{ inputs.attestation }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -96,7 +96,7 @@ runs:
       if: ${{ inputs.attestation == 'true' }}
       uses: actions/attest-build-provenance@v1
       with:
-        subject-path: ${{ steps..package-plugin.outputs.archive }}
+        subject-path: ${{ steps.package-plugin.outputs.archive }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -53,7 +53,8 @@ inputs:
   attestation:
     description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
     required: false
-    default: "false"
+    type: boolean
+    default: false
 
 runs:
   using: "composite"

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -127,4 +127,4 @@ runs:
 
           If the links above are not working, you must first edit this draft release and publish it.
 
-           ${{ inputs.attestation && steps.attestation.outputs.provenance-url && format('This build has been attested. You can view the attestation details [here]({0})', steps.attestation.outputs.attestation-url) }}
+           ${{ inputs.attestation && format('This build has been attested. You can view the attestation details [here]({0})', steps.attestation.outputs.attestation-url) }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -95,6 +95,7 @@ runs:
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation }}
+      id: attestation
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
@@ -125,3 +126,5 @@ runs:
             - Paste this [.zip.sha1 link](https://github.com/${{ github.repository }}/releases/download/v${{ steps.package-plugin.outputs.plugin-version }}/${{ steps.package-plugin.outputs.archive-sha1sum }}) in the SHA1 field
 
           If the links above are not working, you must first edit this draft release and publish it.
+
+           ${{ inputs.attestation && steps.attestation.outputs.provenance-url && format('This build has been attested. You can view the attestation details [here]({0})', steps.attestation.outputs.attestation-url) }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -95,7 +95,7 @@ runs:
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation }}
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@v2
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -34,22 +34,26 @@ inputs:
     type: choice
     description: "Backend target for the plugin backend build"
     options:
-        - build:backend
-        - build:darwin
-        - build:darwinARM64
-        - build:debug
-        - build:debugDarwinAMD64
-        - build:debugDarwinARM64
-        - build:debugLinuxAMD64
-        - build:debugLinuxARM64
-        - build:debugWindowsAMD64
-        - build:linux
-        - build:linuxARM
-        - build:linuxARM64
-        - build:windows
-        - buildAll
+      - build:backend
+      - build:darwin
+      - build:darwinARM64
+      - build:debug
+      - build:debugDarwinAMD64
+      - build:debugDarwinARM64
+      - build:debugLinuxAMD64
+      - build:debugLinuxARM64
+      - build:debugWindowsAMD64
+      - build:linux
+      - build:linuxARM
+      - build:linuxARM64
+      - build:windows
+      - buildAll
     required: false
     default: "buildAll"
+  attestation:
+    description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -87,6 +91,12 @@ runs:
     - name: Check package version
       run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
       shell: bash
+
+    - name: Generate artifact attestation
+      if: ${{ inputs.attestation == 'true' }}
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: ${{ steps..package-plugin.outputs.archive }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Adds a new `attestation: true` option to create a create unfalsifiable provenance of plugin packages build via github actions.

This helps to guarantee plugins built with github actions were built with the provided source code.

The changes guarantee backwards compatibilities with users of the current action.

# Tests

New code without changes to the existing workflow file: https://github.com/academo/testorgdeleteme-test-panel/actions/runs/12870252009/job/35880856651

new code with attestation: true and correct permissions https://github.com/academo/testorgdeleteme-test-panel/actions/runs/12870076674