### PR TITLE
GH Pages actions follow up

### DIFF
--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -70,6 +70,7 @@ runs:
         GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
         TIMESTAMP: ${{ steps.timestampid.outputs.timestamp }}
         JOB_INITIATOR: ${{ env.JOB_INITIATOR }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   
     - name: Write result table in Action summary
       shell: bash

--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -53,14 +53,6 @@ runs:
           echo "JOB_INITIATOR=${{ github.run_id }}" >> "$GITHUB_ENV"
         fi
 
-    - name: Push the new files to github pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        publish_branch: ${{ inputs.pages-branch }}
-        github_token: ${{ inputs.github-token }}
-        publish_dir: all-reports
-        destination_dir: ${{ steps.timestampid.outputs.timestamp }}/${{ env.JOB_INITIATOR }}
-
     - name: Generate Playwright Test Results Table
       id: generate-table
       run: |
@@ -78,6 +70,11 @@ runs:
         GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
         TIMESTAMP: ${{ steps.timestampid.outputs.timestamp }}
         JOB_INITIATOR: ${{ env.JOB_INITIATOR }}
+  
+    - name: Write result table in Action summary
+      shell: bash
+      if: ${{ steps.generate-table.outputs.table != '' }}
+      run: echo "${{ steps.generate-table.outputs.table }}" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Comment PR with Execution Details
       uses: thollander/actions-comment-pull-request@v3
@@ -86,11 +83,14 @@ runs:
         create-if-not-exists: true
         comment-tag: gf-playwright-test-results
         message: ${{ steps.generate-table.outputs.table }}
-  
-    - name: Write result table in Action summary
-      shell: bash
-      if: ${{ steps.generate-table.outputs.table != '' }}
-      run: echo "${{ steps.generate-table.outputs.table }}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Push the new files to github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        publish_branch: ${{ inputs.pages-branch }}
+        github_token: ${{ inputs.github-token }}
+        publish_dir: all-reports
+        destination_dir: ${{ steps.timestampid.outputs.timestamp }}/${{ env.JOB_INITIATOR }}
       
     - name: Checkout code
       uses: actions/checkout@v4
@@ -100,7 +100,6 @@ runs:
     - name: Delete old reports
       shell: bash
       run: ${{ github.action_path }}/cleanup-folders.sh --retention-days ${{ inputs.retention-days }} --folder-name .
-
 
     - name: Commit and push changed files
       shell: bash

--- a/playwright-gh-pages/deploy-report-pages/build-pr-comment.js
+++ b/playwright-gh-pages/deploy-report-pages/build-pr-comment.js
@@ -1,15 +1,21 @@
 const fs = require('fs');
 const path = require('path');
 
-async function checkUrlExists(url) {
-  try {
-    const response = await fetch(url);
-    return response.status !== 404;
-  } catch (error) {
-    console.error('Error fetching URL:', error);
-    return false; // Assume false if there's an error (e.g., network issue)
-  }
-}
+const troubleshootingSection = `\n<details>
+
+<summary> Troubleshooting</summary>
+
+### 404 when clicking on \`View report\`
+
+By default, the \`deploy-report-pages\` Action deploys reports to the \`gh-pages\` branch. However, **you need to take an extra step** to ensure that GitHub Pages can build and serve the site from this branch. To do so:
+
+1. Go to the **Settings** tab of your repository.
+2. In the left-hand sidebar, click on **Pages**.
+3. Under **Source**, select **Deploy from a branch**, then choose the gh-pages branch.
+
+This action needs to be completed **manually** in order for your GitHub Pages site to be built and accessible from the \`gh-pages\` branch. Once configured, GitHub will automatically build and serve the site whenever new reports are deployed.
+
+</details>`;
 
 async function buildPrComment() {
   // Ensure we are in the right directory
@@ -44,7 +50,6 @@ async function buildPrComment() {
   // Initialize an array to store rows
   let rows = [];
   let uploadReportDisabled = false;
-  let lastReportLink = '';
 
   // Iterate through subdirectories
   fs.readdirSync(reportsDir).forEach((dir) => {
@@ -84,10 +89,6 @@ async function buildPrComment() {
     const hasReport = fs.existsSync(path.join(dirPath, 'index.html'));
     const reportCell = hasReport ? `[View report](${reportLink})` : ' ';
 
-    if (hasReport) {
-      lastReportLink = reportLink;
-    }
-
     // Add row to table
     if (usePluginName) {
       rows.push(`| ${pluginName} | ${grafanaImage} | ${grafanaVersion} | ${resultEmoji} | ${reportCell} |`);
@@ -105,28 +106,13 @@ async function buildPrComment() {
   // Add sorted rows to table
   table += '\n' + rows.join('\n') + '\n';
 
+  const ciLink = `https://github.com/${process.env.GITHUB_REPOSITORY_OWNER}/${process.env.GITHUB_REPOSITORY_NAME}/blob/main/.github/workflows/ci.yml`;
   if (uploadReportDisabled) {
-    table +=
-      '\n ⚠️  To be able to browse the Playwright reports for failing end-to-end tests, enable the `upload-report` input in the plugins ci.yml workflow.\n';
+    table += `
+    \n ⚠️  To make Playwright reports for failed tests publicly accessible on GitHub Pages, set the \`upload-report\` input to \`true\` in your [CI workflow](${ciLink}). For more details, refer to the [Developer Portal documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/ci).\n`;
+  } else {
+    table += troubleshootingSection;
   }
-
-  const troubleshootingSection = `\n<details>
-
-<summary> Troubleshooting</summary>
-
-### 404 when clicking on "View report"
-
-By default, the deploy-report-pages Action deploys reports to the gh-pages branch. However, **you need to take an extra step** to ensure that GitHub Pages can build and serve the site from this branch. To do so:
-
-1. Go to the **Settings** tab of your repository.
-2. In the left-hand sidebar, click on **Pages**.
-3. Under **Source**, select **Deploy from a branch**, then choose the gh-pages branch.
-
-This action needs to be completed **manually** in order for your GitHub Pages site to be built and accessible from the gh-pages branch. Once configured, GitHub will automatically build and serve the site whenever new reports are deployed.
-
-</details>`;
-
-  table += troubleshootingSection;
 
   console.log(table);
 }

--- a/playwright-gh-pages/deploy-report-pages/build-pr-comment.js
+++ b/playwright-gh-pages/deploy-report-pages/build-pr-comment.js
@@ -106,7 +106,7 @@ async function buildPrComment() {
   // Add sorted rows to table
   table += '\n' + rows.join('\n') + '\n';
 
-  const ciLink = `https://github.com/${process.env.GITHUB_REPOSITORY_OWNER}/${process.env.GITHUB_REPOSITORY_NAME}/blob/main/.github/workflows/ci.yml`;
+  const ciLink = `https://github.com/${process.env.GITHUB_REPOSITORY_OWNER}/${process.env.GITHUB_REPOSITORY_NAME}/blob/${process.env.DEFAULT_BRANCH}/.github/workflows/ci.yml`;
   if (uploadReportDisabled) {
     table += `
     \n ⚠️  To make Playwright reports for failed tests publicly accessible on GitHub Pages, set the \`upload-report\` input to \`true\` in your [CI workflow](${ciLink}). For more details, refer to the [Developer Portal documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/ci).\n`;

--- a/playwright-gh-pages/upload-report-artifacts/action.yml
+++ b/playwright-gh-pages/upload-report-artifacts/action.yml
@@ -49,15 +49,20 @@ runs:
       shell: bash
       id: add-parent-dir
       run: |
+        if [[ ! -d "${{ inputs.report-dir }}" ]]; then
+          echo "::warning::Report directory '${{ inputs.report-dir }}' does not exist. Skipping this step."
+          exit 0  # exit gracefully without failing the workflow
+        fi
+
         parent_dir="${{ inputs.grafana-image }}-${{ inputs.grafana-version }}"
         if [[ -n "${{ inputs.plugin-name }}" ]]; then
           parent_dir="${{ inputs.plugin-name }}-${{ inputs.grafana-image }}-${{ inputs.grafana-version }}"
         fi
 
-        mv ${{ inputs.report-dir }} $parent_dir
+        mv "${{ inputs.report-dir }}" "$parent_dir"
         mkdir -p playwright-report
-        mv $parent_dir playwright-report/
-        echo "parent-dir=$parent_dir" >> $GITHUB_OUTPUT
+        mv "$parent_dir" playwright-report/
+        echo "parent-dir=$parent_dir" >> "$GITHUB_OUTPUT"
         
 
     - name: Exclude report from artifact 


### PR DESCRIPTION
This PR does some follow up work for the GitHub Pages actions [PR](https://github.com/grafana/plugin-actions/pull/50) that was merged last week.

* Re-order some steps for clarity 
* Add better logging
* Add better PR comment texts, including proper links to docs site
* Remove not used code