### PR TITLE
Create Plugin Update: Fix failing workflow step

### DIFF
--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Get latest version of create-plugin package
       id: get-latest-version
-      run: echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version)" >> "$GITHUB_ENV"
+      run: echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed '/^$/d')" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Checkout Repository


### PR DESCRIPTION
The latest version of create-plugin changed the cli output for `npx @grafana/create-plugin@latest version` from only printing the version to fancy printing the version...

![image](https://github.com/user-attachments/assets/01f9dc99-16d0-454f-a883-01de1c705c9c)

This breaks the create-plugin-update when it tries to get the latest version:

![image](https://github.com/user-attachments/assets/c37a40a9-aa18-4b08-a6ae-5fa01f1c8943)

This PR adds a bit of sed so we can strip everything back to just the version number.