### PR TITLE
Add Generate changelog step to release action

### DIFF
--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -171,8 +171,19 @@ runs:
       shell: bash
 
     - name: Check package version
-      run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
-      shell: bash
+  id: version-check
+  shell: bash
+  run: |
+    PLUGIN_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
+    TAG_VERSION="${{ steps.metadata.outputs.github-tag }}"
+    
+    if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
+      echo "::warning::Version mismatch detected: Plugin version ($PLUGIN_VERSION) doesn't match tag name ($TAG_VERSION)"
+      echo "version_mismatch=true" >> $GITHUB_OUTPUT
+    else
+      echo "Versions match: $PLUGIN_VERSION"
+      echo "version_mismatch=false" >> $GITHUB_OUTPUT
+    fi
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}
@@ -188,7 +199,7 @@ runs:
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
         push: true
-        
+
     - name: Create Github release
       uses: softprops/action-gh-release@v2
       with:

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -81,6 +81,70 @@ runs:
         printf "plugin-id=%s\n" "${{ steps.package-plugin.outputs.plugin-id }}"
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
+    - name: Generate Changelog
+      id: generate-changelog
+      shell: bash
+      run: |
+        CURRENT_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
+        CURRENT_DATE=$(date +"%Y-%m-%d")
+        
+        # Get commit messages since the last tag
+        if git rev-parse --verify --quiet "$(git describe --abbrev=0 --tags 2>/dev/null)"; then
+          LAST_TAG=$(git describe --abbrev=0 --tags)
+          echo "Getting changes since last tag: $LAST_TAG"
+          COMMITS=$(git log --pretty=format:"- %s" $LAST_TAG..HEAD)
+        else
+          echo "No previous tags found. Including all commits."
+          COMMITS=$(git log --pretty=format:"- %s")
+        fi
+        
+        # Create release notes content
+        echo "## $CURRENT_VERSION ($CURRENT_DATE)" > release_notes.md
+        echo "" >> release_notes.md
+        
+        # Categorize commits (optional: you can enhance this to categorize commits by type)
+        echo "### Changes" >> release_notes.md
+        echo "$COMMITS" >> release_notes.md
+        echo "" >> release_notes.md
+        
+        # Save the output for later use
+        echo "path=release_notes.md" >> $GITHUB_OUTPUT
+        
+        # Update CHANGELOG.md
+        if [ -f "CHANGELOG.md" ]; then
+          echo "Updating existing CHANGELOG.md..."
+          # Create a new changelog with the new entry at the top
+          echo "# Changelog" > temp_changelog.md
+          echo "" >> temp_changelog.md
+          cat release_notes.md >> temp_changelog.md
+          echo "" >> temp_changelog.md
+          # Append existing changelog without the header
+          tail -n +3 CHANGELOG.md >> temp_changelog.md
+          mv temp_changelog.md CHANGELOG.md
+        else
+          echo "Creating new CHANGELOG.md..."
+          echo "# Changelog" > CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          cat release_notes.md >> CHANGELOG.md
+        fi
+        
+        # Add version metadata section if it doesn't exist
+        if ! grep -q "## Version Metadata" CHANGELOG.md; then
+          echo "" >> CHANGELOG.md
+          echo "## Version Metadata" >> CHANGELOG.md
+          echo "This section tracks version availability in the Grafana catalog." >> CHANGELOG.md
+        fi
+        
+        # Add the current version to the metadata section with catalog status
+        if [ "${{ inputs.catalog_release }}" == "true" ]; then
+          sed -i "/## Version Metadata/a\\- $CURRENT_VERSION: Released to catalog on $CURRENT_DATE ✓" CHANGELOG.md
+        else
+          sed -i "/## Version Metadata/a\\- $CURRENT_VERSION: Released on $CURRENT_DATE (not in catalog)" CHANGELOG.md
+        fi
+        
+        # Output the path to the updated changelog
+        echo "changelog_path=CHANGELOG.md" >> $GITHUB_OUTPUT
+
     - name: Read changelog
       id: changelog
       run: |
@@ -117,6 +181,14 @@ runs:
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
+    - name: Commit updated changelog
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: 'CHANGELOG.md'
+        message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
+        default_author: github_actions
+        push: true
+        
     - name: Create Github release
       uses: softprops/action-gh-release@v2
       with:

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
-      if: ${{ inputs.use_changelog_generator }}
+      if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: janheinrichmerker/action-github-changelog-generator@v2.3
       with:
         token: ${{ inputs.token }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -81,12 +81,6 @@ runs:
         printf "plugin-id=%s\n" "${{ steps.package-plugin.outputs.plugin-id }}"
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
-    - name: Check environment variable
-      id: check-env
-      run: |
-        echo "USE_CHANGELOG_GENERATOR=${{ env.USE_CHANGELOG_GENERATOR }}" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Checkout code
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: actions/checkout@v3

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -120,12 +120,16 @@ runs:
 
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}
-      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
-      with:
-        add: 'CHANGELOG.md'
-        message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
-        default_author: github_actions
-        push: origin HEAD:${{ github.event.repository.default_branch }}
+      run: |
+        git add CHANGELOG.md
+        
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        git commit -m "docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]"
+        
+        git push origin HEAD:${{ github.event.repository.default_branch }}
+      shell: bash
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -104,19 +104,26 @@ runs:
         fetch-depth: 0  # Important for changelog generation to access full history
         ref: main  # Specify which branch to checkout
 
+    - name: Debug - List recent commits
+      run: |
+        git log --pretty=format:"%h - %s (%cr) <%an>" --date=relative -n 10
+      shell: bash
+
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ inputs.token }}
-        include-commits: true
-        add-sections: '{"commits":{"prefix":"**Commits:**","labels":["Commits"]}}'
-        unreleased: true
-        unreleased-only: false
-        verbose: true
-        simple-list: true
         output: CHANGELOG.md
+        user: ${{ github.repository_owner }}
+        project: ${{ github.event.repository.name }}
+        unreleased: true
+        issues: true
+        pull-requests: true
+        pulls: true
+        include-labels: "bug,enhancement,feature"
+        simple-list: true
 
     - name: Check if changelog was updated
       run: |

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -85,12 +85,6 @@ runs:
         printf "plugin-id=%s\n" "${{ steps.package-plugin.outputs.plugin-id }}"
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
-    - name: Checkout code
-      if: ${{ inputs.use_changelog_generator == 'true' }}
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
     - name: Generate Changelog
       id: github-changelog-generator
       if: ${{ inputs.use_changelog_generator == 'true' }}
@@ -150,7 +144,6 @@ runs:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
-        branch: ${{ steps.target-branch.outputs.name }}
         push: origin HEAD:${{ steps.target-branch.outputs.name }}
 
     - name: Create Github release

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -113,42 +113,13 @@ runs:
     - name: Read changelog
       id: changelog
       run: |
-        if [ -f "CHANGELOG.md" ]; then
-          echo "Changelog found, extracting release notes..."
-          awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
-          # Check if extraction produced any content
-          if [ -s release_notes.md ]; then
-            echo "Release notes extracted successfully."
-          else
-            echo "Warning: Could not extract release notes from CHANGELOG.md in the expected format."
-            echo "Generating default release notes..."
-            echo "## v${{ steps.package-plugin.outputs.plugin-version }}" > release_notes.md
-            echo "" >> release_notes.md
-            echo "This release includes the latest updates for the plugin." >> release_notes.md
-          fi
-        else
-          echo "No CHANGELOG.md found. Generating default release notes..."
-          echo "## v${{ steps.package-plugin.outputs.plugin-version }}" > release_notes.md
-          echo "" >> release_notes.md
-          echo "This release includes the latest updates for the plugin." >> release_notes.md
-        fi
+        awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Check package version
-      id: version-check
+      run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
       shell: bash
-      run: |
-        PLUGIN_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
-        TAG_VERSION="${{ steps.metadata.outputs.github-tag }}"
-        
-        if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
-          echo "::warning::Version mismatch detected: Plugin version ($PLUGIN_VERSION) doesn't match tag name ($TAG_VERSION)"
-          echo "version_mismatch=true" >> $GITHUB_OUTPUT
-        else
-          echo "Versions match: $PLUGIN_VERSION"
-          echo "version_mismatch=false" >> $GITHUB_OUTPUT
-        fi
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -131,6 +131,7 @@ runs:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
+        branch: ${{ github.ref }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -84,6 +84,7 @@ runs:
     - name: Read changelog
       id: changelog
       run: |
+        echo "CHANGELOG.md"
         awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
       shell: bash

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -84,8 +84,25 @@ runs:
     - name: Read changelog
       id: changelog
       run: |
-        echo "CHANGELOG.md"
-        awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
+        if [ -f "CHANGELOG.md" ]; then
+          echo "Changelog found, extracting release notes..."
+          awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
+          # Check if extraction produced any content
+          if [ -s release_notes.md ]; then
+            echo "Release notes extracted successfully."
+          else
+            echo "Warning: Could not extract release notes from CHANGELOG.md in the expected format."
+            echo "Generating default release notes..."
+            echo "## v${{ steps.package-plugin.outputs.plugin-version }}" > release_notes.md
+            echo "" >> release_notes.md
+            echo "This release includes the latest updates for the plugin." >> release_notes.md
+          fi
+        else
+          echo "No CHANGELOG.md found. Generating default release notes..."
+          echo "## v${{ steps.package-plugin.outputs.plugin-version }}" > release_notes.md
+          echo "" >> release_notes.md
+          echo "This release includes the latest updates for the plugin." >> release_notes.md
+        fi
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -81,6 +81,12 @@ runs:
         printf "plugin-id=%s\n" "${{ steps.package-plugin.outputs.plugin-id }}"
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
+    - name: Check environment variable
+      id: check-env
+      run: |
+        echo "USE_CHANGELOG_GENERATOR=${{ env.USE_CHANGELOG_GENERATOR }}" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
       if: ${{ env.USE_CHANGELOG_GENERATOR }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -87,18 +87,38 @@ runs:
         echo "USE_CHANGELOG_GENERATOR=${{ env.USE_CHANGELOG_GENERATOR }}" >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Save original changelog state
+      run: |
+        if [ -f "CHANGELOG.md" ]; then
+          cp CHANGELOG.md CHANGELOG.md.backup
+          echo "ORIGINAL_CHANGELOG_EXISTS=true" >> $GITHUB_ENV
+        else
+          echo "ORIGINAL_CHANGELOG_EXISTS=false" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
-      uses: janheinrichmerker/action-github-changelog-generator@v2.3
+      uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ inputs.token }}
         output: CHANGELOG.md
-    
-    - name: Read generatedchangelog
-      id: read-generated-changelog
+
+    - name: Check if changelog was updated
       run: |
-        echo "Generated Changelog: ${{ steps.github-changelog-generator.outputs.changelog }}" >> $GITHUB_OUTPUT
+        if [ "$ORIGINAL_CHANGELOG_EXISTS" = "true" ]; then
+          if cmp -s "CHANGELOG.md" "CHANGELOG.md.backup"; then
+            echo "Changelog content was not changed"
+            echo "CHANGELOG_UPDATED=false" >> $GITHUB_ENV
+          else
+            echo "Changelog was updated with new content"
+            echo "CHANGELOG_UPDATED=true" >> $GITHUB_ENV
+          fi
+        else
+          echo "Changelog was newly created"
+          echo "CHANGELOG_UPDATED=true" >> $GITHUB_ENV
+        fi
       shell: bash
 
     - name: Read changelog

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -110,8 +110,12 @@ runs:
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ inputs.token }}
-        include-commits: true             # Include all commits
+        include-commits: true
         add-sections: '{"commits":{"prefix":"**Commits:**","labels":["Commits"]}}'
+        unreleased: true
+        unreleased-only: false
+        verbose: true
+        simple-list: true
         output: CHANGELOG.md
 
     - name: Check if changelog was updated

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -93,7 +93,12 @@ runs:
       uses: janheinrichmerker/action-github-changelog-generator@v2.3
       with:
         token: ${{ inputs.token }}
-        output: CHANGELOG.md
+    
+    - name: Read generatedchangelog
+      id: read-generated-changelog
+      run: |
+        echo "Generated Changelog: ${{ steps.github-changelog-generator.outputs.changelog }}" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: Read changelog
       id: changelog

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -88,7 +88,7 @@ runs:
     - name: Generate Changelog
       id: github-changelog-generator
       if: ${{ inputs.use_changelog_generator == 'true' }}
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      uses: janheinrichmerker/action-github-changelog-generator@e60b5a2bd9fcd88dadf6345ff8327863fb8b490f # v2.4
       with:
         token: ${{ inputs.token }}
         output: CHANGELOG.md
@@ -107,9 +107,9 @@ runs:
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
       shell: bash
 
-    # - name: Check package version
-    #   run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
-    #   shell: bash
+    - name: Check package version
+      run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
+      shell: bash
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}
@@ -117,17 +117,6 @@ runs:
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
-
-    # - name: Determine target branch for push
-    #   if: ${{ inputs.use_changelog_generator == 'true' }}
-    #   id: target-branch
-    #   shell: bash
-    #   run: |
-    #     git remote set-head origin -a
-    #     DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-    #     echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
-    #     echo "Using default branch: $DEFAULT_BRANCH"
-        
 
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -132,6 +132,7 @@ runs:
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
         branch: ${{ github.ref }}
+        push: origin HEAD:${{ github.ref }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -124,6 +124,25 @@ runs:
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
+    - name: Determine target branch for push
+      if: ${{ inputs.use_changelog_generator == 'true' }}
+      id: target-branch
+      shell: bash
+      run: |
+        # Check if we're on a tag reference
+        if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          # Get the default branch when we're on a tag
+          git remote set-head origin -a
+          DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+          echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
+          echo "Using default branch: $DEFAULT_BRANCH (because we're on a tag)"
+        else
+          # Get current branch name when not on a tag
+          BRANCH=${GITHUB_REF#refs/heads/}
+          echo "name=$BRANCH" >> $GITHUB_OUTPUT
+          echo "Using current branch: $BRANCH"
+        fi
+
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}
       uses: EndBug/add-and-commit@v9
@@ -131,8 +150,7 @@ runs:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
-        branch: ${{ github.ref }}
-        push: origin HEAD:${{ github.ref }}
+        branch: ${{ steps.target-branch.outputs.name }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -120,7 +120,7 @@ runs:
 
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       with:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -118,15 +118,15 @@ runs:
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
-    - name: Determine target branch for push
-      if: ${{ inputs.use_changelog_generator == 'true' }}
-      id: target-branch
-      shell: bash
-      run: |
-        git remote set-head origin -a
-        DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-        echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
-        echo "Using default branch: $DEFAULT_BRANCH"
+    # - name: Determine target branch for push
+    #   if: ${{ inputs.use_changelog_generator == 'true' }}
+    #   id: target-branch
+    #   shell: bash
+    #   run: |
+    #     git remote set-head origin -a
+    #     DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+    #     echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
+    #     echo "Using default branch: $DEFAULT_BRANCH"
         
 
     - name: Commit updated changelog
@@ -136,7 +136,7 @@ runs:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
-        push: origin HEAD:${{ steps.target-branch.outputs.name }}
+        push: origin HEAD:${{ github.event.repository.default_branch }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
-      if: ${{ inputs.use_changelog_generator == 'true' }}
+      if: ${{ inputs.use_changelog_generator }}
       uses: janheinrichmerker/action-github-changelog-generator@v2.3
       with:
         token: ${{ inputs.token }}
@@ -115,19 +115,19 @@ runs:
       shell: bash
 
     - name: Check package version
-  id: version-check
-  shell: bash
-  run: |
-    PLUGIN_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
-    TAG_VERSION="${{ steps.metadata.outputs.github-tag }}"
-    
-    if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
-      echo "::warning::Version mismatch detected: Plugin version ($PLUGIN_VERSION) doesn't match tag name ($TAG_VERSION)"
-      echo "version_mismatch=true" >> $GITHUB_OUTPUT
-    else
-      echo "Versions match: $PLUGIN_VERSION"
-      echo "version_mismatch=false" >> $GITHUB_OUTPUT
-    fi
+      id: version-check
+      shell: bash
+      run: |
+        PLUGIN_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
+        TAG_VERSION="${{ steps.metadata.outputs.github-tag }}"
+        
+        if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
+          echo "::warning::Version mismatch detected: Plugin version ($PLUGIN_VERSION) doesn't match tag name ($TAG_VERSION)"
+          echo "version_mismatch=true" >> $GITHUB_OUTPUT
+        else
+          echo "Versions match: $PLUGIN_VERSION"
+          echo "version_mismatch=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -97,6 +97,13 @@ runs:
         fi
       shell: bash
 
+    - name: Checkout code
+      if: ${{ env.USE_CHANGELOG_GENERATOR }}
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Important for changelog generation to access full history
+        ref: main  # Specify which branch to checkout
+
     - name: Generate Changelog using github-changelog-generator
       id: github-changelog-generator
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
@@ -175,6 +182,7 @@ runs:
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
         push: true
+        branch: main
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -81,69 +81,13 @@ runs:
         printf "plugin-id=%s\n" "${{ steps.package-plugin.outputs.plugin-id }}"
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
-    - name: Generate Changelog
-      id: generate-changelog
-      shell: bash
-      run: |
-        CURRENT_VERSION="v${{ steps.package-plugin.outputs.plugin-version }}"
-        CURRENT_DATE=$(date +"%Y-%m-%d")
-        
-        # Get commit messages since the last tag
-        if git rev-parse --verify --quiet "$(git describe --abbrev=0 --tags 2>/dev/null)"; then
-          LAST_TAG=$(git describe --abbrev=0 --tags)
-          echo "Getting changes since last tag: $LAST_TAG"
-          COMMITS=$(git log --pretty=format:"- %s" $LAST_TAG..HEAD)
-        else
-          echo "No previous tags found. Including all commits."
-          COMMITS=$(git log --pretty=format:"- %s")
-        fi
-        
-        # Create release notes content
-        echo "## $CURRENT_VERSION ($CURRENT_DATE)" > release_notes.md
-        echo "" >> release_notes.md
-        
-        # Categorize commits (optional: you can enhance this to categorize commits by type)
-        echo "### Changes" >> release_notes.md
-        echo "$COMMITS" >> release_notes.md
-        echo "" >> release_notes.md
-        
-        # Save the output for later use
-        echo "path=release_notes.md" >> $GITHUB_OUTPUT
-        
-        # Update CHANGELOG.md
-        if [ -f "CHANGELOG.md" ]; then
-          echo "Updating existing CHANGELOG.md..."
-          # Create a new changelog with the new entry at the top
-          echo "# Changelog" > temp_changelog.md
-          echo "" >> temp_changelog.md
-          cat release_notes.md >> temp_changelog.md
-          echo "" >> temp_changelog.md
-          # Append existing changelog without the header
-          tail -n +3 CHANGELOG.md >> temp_changelog.md
-          mv temp_changelog.md CHANGELOG.md
-        else
-          echo "Creating new CHANGELOG.md..."
-          echo "# Changelog" > CHANGELOG.md
-          echo "" >> CHANGELOG.md
-          cat release_notes.md >> CHANGELOG.md
-        fi
-        
-        # Add version metadata section if it doesn't exist
-        if ! grep -q "## Version Metadata" CHANGELOG.md; then
-          echo "" >> CHANGELOG.md
-          echo "## Version Metadata" >> CHANGELOG.md
-          echo "This section tracks version availability in the Grafana catalog." >> CHANGELOG.md
-        fi
-        
-        # Add the current version to the metadata section with catalog status
-        if [ "${{ inputs.catalog_release }}" == "true" ]; then
-          sed -i "/## Version Metadata/a\\- $CURRENT_VERSION: Released to catalog on $CURRENT_DATE ✓" CHANGELOG.md
-        else
-          sed -i "/## Version Metadata/a\\- $CURRENT_VERSION: Released on $CURRENT_DATE (not in catalog)" CHANGELOG.md
-        fi
-        
-        # Output the path to the updated changelog
-        echo "changelog_path=CHANGELOG.md" >> $GITHUB_OUTPUT
+    - name: Generate Changelog using github-changelog-generator
+      id: github-changelog-generator
+      if: ${{ inputs.use_changelog_generator == 'true' }}
+      uses: janheinrichmerker/action-github-changelog-generator@v2.3
+      with:
+        token: ${{ inputs.token }}
+        output: CHANGELOG.md
 
     - name: Read changelog
       id: changelog

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -87,29 +87,14 @@ runs:
         echo "USE_CHANGELOG_GENERATOR=${{ env.USE_CHANGELOG_GENERATOR }}" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Save original changelog state
-      run: |
-        if [ -f "CHANGELOG.md" ]; then
-          cp CHANGELOG.md CHANGELOG.md.backup
-          echo "ORIGINAL_CHANGELOG_EXISTS=true" >> $GITHUB_ENV
-        else
-          echo "ORIGINAL_CHANGELOG_EXISTS=false" >> $GITHUB_ENV
-        fi
-      shell: bash
-
     - name: Checkout code
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0  # Important for changelog generation to access full history
-        ref: main  # Specify which branch to checkout
+        fetch-depth: 0
+        ref: main
 
-    - name: Debug - List recent commits
-      run: |
-        git log --pretty=format:"%h - %s (%cr) <%an>" --date=relative -n 10
-      shell: bash
-
-    - name: Generate Changelog using github-changelog-generator
+    - name: Generate Changelog
       id: github-changelog-generator
       if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
@@ -124,22 +109,6 @@ runs:
         pulls: true
         include-labels: "bug,enhancement,feature"
         simple-list: true
-
-    - name: Check if changelog was updated
-      run: |
-        if [ "$ORIGINAL_CHANGELOG_EXISTS" = "true" ]; then
-          if cmp -s "CHANGELOG.md" "CHANGELOG.md.backup"; then
-            echo "Changelog content was not changed"
-            echo "CHANGELOG_UPDATED=false" >> $GITHUB_ENV
-          else
-            echo "Changelog was updated with new content"
-            echo "CHANGELOG_UPDATED=true" >> $GITHUB_ENV
-          fi
-        else
-          echo "Changelog was newly created"
-          echo "CHANGELOG_UPDATED=true" >> $GITHUB_ENV
-        fi
-      shell: bash
 
     - name: Read changelog
       id: changelog
@@ -189,6 +158,7 @@ runs:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
     - name: Commit updated changelog
+      if: ${{ env.USE_CHANGELOG_GENERATOR }}
       uses: EndBug/add-and-commit@v9
       with:
         add: 'CHANGELOG.md'

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -93,6 +93,7 @@ runs:
       uses: janheinrichmerker/action-github-changelog-generator@v2.3
       with:
         token: ${{ inputs.token }}
+        output: CHANGELOG.md
     
     - name: Read generatedchangelog
       id: read-generated-changelog

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -151,6 +151,7 @@ runs:
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
         branch: ${{ steps.target-branch.outputs.name }}
+        push: origin HEAD:${{ steps.target-branch.outputs.name }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -131,8 +131,6 @@ runs:
         add: 'CHANGELOG.md'
         message: 'docs: update changelog for ${{ steps.package-plugin.outputs.plugin-version }} [skip ci]'
         default_author: github_actions
-        push: true
-        branch: main
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -110,6 +110,8 @@ runs:
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ inputs.token }}
+        include-commits: true             # Include all commits
+        add-sections: '{"commits":{"prefix":"**Commits:**","labels":["Commits"]}}'
         output: CHANGELOG.md
 
     - name: Check if changelog was updated

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -107,9 +107,9 @@ runs:
         echo "path=release_notes.md" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Check package version
-      run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
-      shell: bash
+    # - name: Check package version
+    #   run: if [ "v${{ steps.package-plugin.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${{ steps.package-plugin.outputs.plugin-version }} \033[0m\n"; exit 1; fi
+    #   shell: bash
 
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}
@@ -123,19 +123,11 @@ runs:
       id: target-branch
       shell: bash
       run: |
-        # Check if we're on a tag reference
-        if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-          # Get the default branch when we're on a tag
-          git remote set-head origin -a
-          DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-          echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
-          echo "Using default branch: $DEFAULT_BRANCH (because we're on a tag)"
-        else
-          # Get current branch name when not on a tag
-          BRANCH=${GITHUB_REF#refs/heads/}
-          echo "name=$BRANCH" >> $GITHUB_OUTPUT
-          echo "Using current branch: $BRANCH"
-        fi
+        git remote set-head origin -a
+        DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+        echo "name=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
+        echo "Using default branch: $DEFAULT_BRANCH"
+        
 
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
     required: false
     default: "false"
+  use_changelog_generator:
+    description: "Whether to generate a changelog for the plugin"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -82,15 +86,14 @@ runs:
         printf "plugin-version=%s\n" "${{ steps.package-plugin.outputs.plugin-version }}"
 
     - name: Checkout code
-      if: ${{ env.USE_CHANGELOG_GENERATOR }}
+      if: ${{ inputs.use_changelog_generator == 'true' }}
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: main
 
     - name: Generate Changelog
       id: github-changelog-generator
-      if: ${{ env.USE_CHANGELOG_GENERATOR }}
+      if: ${{ inputs.use_changelog_generator == 'true' }}
       uses: janheinrichmerker/action-github-changelog-generator@v2.4
       with:
         token: ${{ inputs.token }}
@@ -99,10 +102,9 @@ runs:
         project: ${{ github.event.repository.name }}
         unreleased: true
         issues: true
-        pull-requests: true
-        pulls: true
-        include-labels: "bug,enhancement,feature"
-        simple-list: true
+        pullRequests: true
+        includeLabels: "bug,enhancement,feature"
+        simpleList: true
 
     - name: Read changelog
       id: changelog
@@ -123,7 +125,7 @@ runs:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
     - name: Commit updated changelog
-      if: ${{ env.USE_CHANGELOG_GENERATOR }}
+      if: ${{ inputs.use_changelog_generator == 'true' }}
       uses: EndBug/add-and-commit@v9
       with:
         add: 'CHANGELOG.md'


### PR DESCRIPTION
We want developers provide a good changelog, because we are displaying it in plugin details. With this change we can help some devs who does not want to fill changelog by themselves. They can add with: use_changelog_generator: true to their github action and it will run changelog generation. 

The action I am using is https://github.com/janheinrichmerker/action-github-changelog-generator - based on https://github.com/github-changelog-generator/github-changelog-generator

I tested this on my plugin repo https://github.com/Ukochka/grafana-changelog-panel/blob/main/CHANGELOG.md
