### PR TITLE
Create Plugin Update: Fix pnpm install + update_needed check

### DIFF
--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Get latest version of create-plugin package
       id: get-latest-version
       run: |
-        echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed 's/ *$//' | sed '/^$/d')" | tee -a "$GITHUB_ENV"
+        echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed 's/ *$//' | sed '/^$/d')" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Checkout Repository
@@ -38,16 +38,16 @@ runs:
     - name: Get version from .config/.cprc.json
       id: get-config-version
       run: |
-        echo "CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)" | tee -a "$GITHUB_ENV"
+        echo "CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Compare versions
       id: compare-versions
       run: |
         if [ "$LATEST_VERSION" != "$CONFIG_VERSION" ]; then
-          echo "update_needed=true" | tee -a "$GITHUB_OUTPUT"
+          echo "update_needed=true" >> "$GITHUB_OUTPUT"
         else
-          echo "update_needed=false" | tee -a "$GITHUB_OUTPUT"
+          echo "update_needed=false" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 

--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -25,7 +25,8 @@ runs:
 
     - name: Get latest version of create-plugin package
       id: get-latest-version
-      run: echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed '/^$/d')" | tee -a "$GITHUB_ENV"
+      run: |
+        echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed 's/ *$//' | sed '/^$/d')" | tee -a "$GITHUB_ENV"
       shell: bash
 
     - name: Checkout Repository
@@ -36,7 +37,8 @@ runs:
 
     - name: Get version from .config/.cprc.json
       id: get-config-version
-      run: echo "CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)" | tee -a "$GITHUB_ENV"
+      run: |
+        echo "CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)" | tee -a "$GITHUB_ENV"
       shell: bash
 
     - name: Compare versions

--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Get latest version of create-plugin package
       id: get-latest-version
-      run: echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed '/^$/d')" >> "$GITHUB_ENV"
+      run: echo "LATEST_VERSION=$(npx -y @grafana/create-plugin@latest version | sed 's/.*@//' | sed '/^$/d')" | tee -a "$GITHUB_ENV"
       shell: bash
 
     - name: Checkout Repository
@@ -36,18 +36,16 @@ runs:
 
     - name: Get version from .config/.cprc.json
       id: get-config-version
-      run: |
-        CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)
-        echo "CONFIG_VERSION=${CONFIG_VERSION}" >> "$GITHUB_ENV"
+      run: echo "CONFIG_VERSION=$(jq -r '.version' .config/.cprc.json)" | tee -a "$GITHUB_ENV"
       shell: bash
 
     - name: Compare versions
       id: compare-versions
       run: |
         if [ "$LATEST_VERSION" != "$CONFIG_VERSION" ]; then
-          echo "update_needed=true" >> $GITHUB_OUTPUT
+          echo "update_needed=true" | tee -a "$GITHUB_OUTPUT"
         else
-          echo "update_needed=false" >> $GITHUB_OUTPUT
+          echo "update_needed=false" | tee -a "$GITHUB_OUTPUT"
         fi
       shell: bash
 

--- a/create-plugin-update/pm.sh
+++ b/create-plugin-update/pm.sh
@@ -18,15 +18,15 @@ install_pnpm_if_not_present() {
 # to determine the correct installation command
 # and the exec command to run create-plugin update
 if [ -f yarn.lock ]; then
-	pmi=("yarn" "install")
-	pmu=("yarn" "create" "@grafana/plugin" "update")
+	install_deps=("yarn" "install")
+	create_plugin_update=("yarn" "create" "@grafana/plugin" "update")
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present
-	pmi=("pnpm" "install" "--no-frozen-lockfile")
-	pmu=("pnpm" "dlx" "@grafana/create-plugin@latest" "update")
+	install_deps=("pnpm" "install" "--no-frozen-lockfile")
+	create_plugin_update=("pnpm" "dlx" "@grafana/create-plugin@latest" "update")
 elif [ -f package-lock.json ]; then
-	pmi=("npm" "install")
-	pmu=("npx" "-y" "@grafana/create-plugin@latest" "update")
+	install_deps=("npm" "install")
+	create_plugin_update=("npx" "-y" "@grafana/create-plugin@latest" "update")
 else
 	echo "No recognized package manager found in this project."
 	exit 1
@@ -34,9 +34,9 @@ fi
 
 # Run the provided command with the detected package manager
 if [ "$1" = "install" ]; then
-	echo "Running '$1' with ${pmi[0]}..."
-	"${pmi[@]}"
+	echo "Running '$1' with ${install_deps[0]}..."
+	"${install_deps[@]}"
 elif [ "$1" = "update" ]; then
-	echo "Running '$1' with ${pmu[0]}..."
-	"${pmu[@]}"
+	echo "Running '$1' with ${create_plugin_update[0]}..."
+	"${create_plugin_update[@]}"
 fi

--- a/create-plugin-update/pm.sh
+++ b/create-plugin-update/pm.sh
@@ -15,21 +15,18 @@ install_pnpm_if_not_present() {
 }
 
 # Detect the package manager
-# and the args to run installation
-# and the exec command to run create-plugin
+# to determine the correct installation command
+# and the exec command to run create-plugin update
 if [ -f yarn.lock ]; then
-	pm="yarn"
-	pmi=()
-	pmx=("yarn" "create" "@grafana/plugin")
+	pmi=("yarn" "install")
+	pmu=("yarn" "create" "@grafana/plugin" "update")
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present
-	pm="pnpm"
-	pmi=("--no-frozen-lockfile")
-	pmx=("pnpm" "dlx" "@grafana/create-plugin@latest")
+	pmi=("pnpm" "install" "--no-frozen-lockfile")
+	pmu=("pnpm" "dlx" "@grafana/create-plugin@latest" "update")
 elif [ -f package-lock.json ]; then
-	pm="npm"
-	pmi=()
-	pmx=("npx" "-y" "@grafana/create-plugin@latest")
+	pmi=("npm" "install")
+	pmu=("npx" "-y" "@grafana/create-plugin@latest" "update")
 else
 	echo "No recognized package manager found in this project."
 	exit 1
@@ -37,9 +34,9 @@ fi
 
 # Run the provided command with the detected package manager
 if [ "$1" = "install" ]; then
-	echo "Running '$1' with $pm..."
-	"$pm" install "${pmi[@]}"
+	echo "Running '$1' with ${pmi[0]}..."
+	"${pmi[@]}"
 elif [ "$1" = "update" ]; then
-	echo "Running '$1' with ${pmx[0]}..."
-	"${pmx[@]}" update
+	echo "Running '$1' with ${pmu[0]}..."
+	"${pmu[@]}"
 fi

--- a/create-plugin-update/pm.sh
+++ b/create-plugin-update/pm.sh
@@ -15,29 +15,20 @@ install_pnpm_if_not_present() {
 }
 
 # Detect the package manager
+# and the exec command to run create-plugin update
 if [ -f yarn.lock ]; then
 	pm="yarn"
+	pmx=("yarn" "create" "@grafana/plugin")
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present
 	pm="pnpm"
+	pmx=("pnpm" "dlx" "@grafana/create-plugin@latest")
 elif [ -f package-lock.json ]; then
 	pm="npm"
+	pmx=("npx" "-y" "@grafana/create-plugin@latest")
 else
 	echo "No recognized package manager found in this project."
 	exit 1
-fi
-
-# Detect the exec command to run create-plugin update
-if [ -f yarn.lock ]; then
-  pmx=("yarn" "create" "@grafana/plugin")
-elif [ -f pnpm-lock.yaml ]; then
-  install_pnpm_if_not_present
-  pmx=("pnpm" "dlx" "@grafana/create-plugin@latest")
-elif [ -f package-lock.json ]; then
-  pmx=("npx" "-y" "@grafana/create-plugin@latest")
-else
-  echo "No recognized package manager found in this project."
-  exit 1
 fi
 
 # Run the provided command with the detected package manager

--- a/create-plugin-update/pm.sh
+++ b/create-plugin-update/pm.sh
@@ -15,16 +15,20 @@ install_pnpm_if_not_present() {
 }
 
 # Detect the package manager
-# and the exec command to run create-plugin update
+# and the args to run installation
+# and the exec command to run create-plugin
 if [ -f yarn.lock ]; then
 	pm="yarn"
+	pmi=()
 	pmx=("yarn" "create" "@grafana/plugin")
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present
 	pm="pnpm"
+	pmi=("--no-frozen-lockfile")
 	pmx=("pnpm" "dlx" "@grafana/create-plugin@latest")
 elif [ -f package-lock.json ]; then
 	pm="npm"
+	pmi=()
 	pmx=("npx" "-y" "@grafana/create-plugin@latest")
 else
 	echo "No recognized package manager found in this project."
@@ -33,9 +37,9 @@ fi
 
 # Run the provided command with the detected package manager
 if [ "$1" = "install" ]; then
-  echo "Running '$1' with $pm..."
-	"$pm" install
+	echo "Running '$1' with $pm..."
+	"$pm" install "${pmi[@]}"
 elif [ "$1" = "update" ]; then
-  echo "Running '$1' with ${pmx[0]}..."
+	echo "Running '$1' with ${pmx[0]}..."
 	"${pmx[@]}" update
 fi


### PR DESCRIPTION
Links to private repos, sorry non-Grafanistas:

- Initial failed run due to `pnpm install` defaulting to `--frozen-lockfile` due to CI environment: https://github.com/grafana/grafana-setupguide-app/actions/runs/14323007741/job/40143357659
- With that fixed (setting `--no-frozen-lockfile`, and logging added, the `pnpm install` call worked, but a PR was incorrectly created in run when `LATEST_VERSION` and `CONFIG_VERSION` matched: https://github.com/grafana/grafana-setupguide-app/actions/runs/14323285672/job/40144128607
- With that fixed (trimming whitespace from `LATEST_VERSION`), a successful run that exited cleanly early due to matching versions: https://github.com/grafana/grafana-setupguide-app/actions/runs/14323432204/job/40144543950

I would appreciate someone testing this w/ yarn/npm to confirm my changes haven't broken non-pnpm folks :)