### PR TITLE
Create Plugin Update: Use lowercase PR title for conventional commits

### DIFF
--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
+  pr-prefix:
+    description: "Prefix for pull request title"
+    default: "Chore: "
 
 runs:
   using: "composite"
@@ -76,6 +79,8 @@ runs:
       run: |
         PR_NUMBER=$(gh pr list --base ${{ inputs.base }} --head update-grafana-create-plugin-${{ env.LATEST_VERSION }} --json number -q '.[0].number')
 
+        PR_TITLE="${{ inputs.pr-prefix }}Bump @grafana/create-plugin configuration to ${{ env.LATEST_VERSION }}"
+
         PR_BODY=$(cat <<EOF
         Bumps [\`@grafana/create-plugin\`](https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin) configuration from ${{ env.CONFIG_VERSION }} to ${{ env.LATEST_VERSION }}.
 
@@ -87,8 +92,8 @@ runs:
         )
 
         if [ -z "$PR_NUMBER" ]; then
-          gh pr create --base ${{ inputs.base }} --head update-grafana-create-plugin-${{ env.LATEST_VERSION }} --title "Chore: Bump @grafana/create-plugin configuration to ${{ env.LATEST_VERSION }}" --body "$PR_BODY"
+          gh pr create --base ${{ inputs.base }} --head update-grafana-create-plugin-${{ env.LATEST_VERSION }} --title "$PR_TITLE" --body "$PR_BODY"
         else
-          gh pr edit $PR_NUMBER --title "Chore: Bump @grafana/create-plugin configuration to ${{ env.LATEST_VERSION }}" --body "$PR_BODY"
+          gh pr edit $PR_NUMBER --title "$PR_TITLE" --body "$PR_BODY"
         fi
       shell: bash

--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -14,9 +14,6 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
-  pr-title:
-    description: "Set the pull request title. Can use ${LATEST_VERSION} and ${CONFIG_VERSION}."
-    default: "Chore: Bump @grafana/create-plugin configuration to ${LATEST_VERSION}"
 
 runs:
   using: "composite"
@@ -79,7 +76,7 @@ runs:
       run: |
         PR_NUMBER=$(gh pr list --base ${{ inputs.base }} --head update-grafana-create-plugin-${{ env.LATEST_VERSION }} --json number -q '.[0].number')
 
-        PR_TITLE=$(echo "${{ inputs.pr-title }}" | sed 's/\${CONFIG_VERSION}/${{ env.CONFIG_VERSION }}/' | sed 's/\${LATEST_VERSION}/${{ env.LATEST_VERSION }}/')
+        PR_TITLE="chore: bump @grafana/create-plugin configuration to ${{ env.LATEST_VERSION }}"
 
         PR_BODY=$(cat <<EOF
         Bumps [\`@grafana/create-plugin\`](https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin) configuration from ${{ env.CONFIG_VERSION }} to ${{ env.LATEST_VERSION }}.

--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -14,9 +14,9 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
-  pr-prefix:
-    description: "Prefix for pull request title"
-    default: "Chore: "
+  pr-title:
+    description: "Set the pull request title. Can use ${LATEST_VERSION} and ${CONFIG_VERSION}."
+    default: "Chore: Bump @grafana/create-plugin configuration to ${LATEST_VERSION}"
 
 runs:
   using: "composite"
@@ -79,7 +79,7 @@ runs:
       run: |
         PR_NUMBER=$(gh pr list --base ${{ inputs.base }} --head update-grafana-create-plugin-${{ env.LATEST_VERSION }} --json number -q '.[0].number')
 
-        PR_TITLE="${{ inputs.pr-prefix }}Bump @grafana/create-plugin configuration to ${{ env.LATEST_VERSION }}"
+        PR_TITLE=$(echo "${{ inputs.pr-title }}" | sed 's/\${CONFIG_VERSION}/${{ env.CONFIG_VERSION }}/' | sed 's/\${LATEST_VERSION}/${{ env.LATEST_VERSION }}/')
 
         PR_BODY=$(cat <<EOF
         Bumps [\`@grafana/create-plugin\`](https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin) configuration from ${{ env.CONFIG_VERSION }} to ${{ env.LATEST_VERSION }}.


### PR DESCRIPTION
~~Allows for a custom PR title to be set, so alternatives like `chore(deps): ...` can be used. Can be seen working successfully in https://github.com/grafana/grafana-setupguide-app/actions/runs/14465253476/job/40566049790 / https://github.com/grafana/grafana-setupguide-app/pull/127 (private repo, sorry non-Grafanistas).~~

Updates the default title used when creating a PR to be lowercase, so that it is more compatible with projects using conventional commits.