### PR TITLE
Bundle-types: fix access to plugin-types repo

### DIFF
--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -67,10 +67,10 @@ runs:
 
     - name: Generate token
       id: generate-token
-      uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
       with:
-        app-id: ${{ env.GITHUB_APP_ID }}
-        private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+        app_id: ${{ env.GITHUB_APP_ID }}
+        private_key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
     - name: Clone NPM types package repo
       run: |


### PR DESCRIPTION
Something in the official github app token action is preventing the token from being able access the plugin-types repo.

Putting it back to use tibdex/github-app-token appears to resolve this issue.