### PR TITLE
Chore: switch back to official auth action

### DIFF
--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -76,7 +76,7 @@ runs:
       run: |
         cd ..
         gh auth status
-        gh repo clone grafana/plugin-extension-types
+        gh repo clone git@github.com:grafana/plugin-extension-types.git
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -71,12 +71,14 @@ runs:
       with:
         app-id: ${{ env.GITHUB_APP_ID }}
         private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+        owner: grafana
+        repository: plugin-extension-types
 
     - name: Clone NPM types package repo
       run: |
         cd ..
         gh auth status
-        gh repo clone git@github.com:grafana/plugin-extension-types.git
+        gh repo clone grafana/plugin-extension-types
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -71,7 +71,11 @@ runs:
       with:
         app-id: ${{ env.GITHUB_APP_ID }}
         private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-        owner: grafana        
+        owner: grafana
+        repositories: |
+            plugin-extension-types
+
+
 
     - name: Clone NPM types package repo
       run: |

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -67,10 +67,10 @@ runs:
 
     - name: Generate token
       id: generate-token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
       with:
-        app_id: ${{ env.GITHUB_APP_ID }}
-        private_key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+        app-id: ${{ env.GITHUB_APP_ID }}
+        private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
     - name: Clone NPM types package repo
       run: |

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -71,8 +71,7 @@ runs:
       with:
         app-id: ${{ env.GITHUB_APP_ID }}
         private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-        owner: grafana
-        repository: plugin-extension-types
+        owner: grafana        
 
     - name: Clone NPM types package repo
       run: |


### PR DESCRIPTION
- Test run https://github.com/grafana/plugins-platform-app/actions/runs/14904028930/job/41862600386#step:3:250
- Test run without `repository` property https://github.com/grafana/plugins-platform-app/actions/runs/14904295175/job/41863035757 this creates token for all repos
-  **latest** run with repositories property https://github.com/grafana/plugins-platform-app/actions/runs/14904390913/job/41863325781#step:3:253
- drilldown run https://github.com/grafana/traces-drilldown/actions/runs/14904456458/job/41863528408