### PR TITLE
e2e-versions: Add plugin-directory input for plugins in subdirectories

### DIFF
--- a/e2e-version/README.md
+++ b/e2e-version/README.md
@@ -12,12 +12,16 @@ By default, this actions resolves an image for the latest build of the main bran
 
 The maximum number of versions to resolve. Default is 6, 0 means no limit.
 
+### `plugin-directory`
+
+The directory where `plugin.json` is located. It defaults to `src`, which works for monorepos where the plugin is in the root of the repository.
+
 ### `version-resolver-type`
 
 The action supports two modes.
 
 **plugin-grafana-dependency (default)**
-The will return the most recent grafana-dev image and all the latest patch release of every minor version of Grafana Enterprise that satisfies the range specified in the [dependencies.grafanaDependency](https://grafana.com/developers/plugin-tools/reference/plugin-json#properties-1) property in plugin.json. This requires the plugin.json file to be placed in the `<root>/src` directory. To avoid starting too many jobs, to output will be capped 6 versions.
+The will return the most recent grafana-dev image and all the latest patch release of every minor version of Grafana Enterprise that satisfies the range specified in the [dependencies.grafanaDependency](https://grafana.com/developers/plugin-tools/reference/plugin-json#properties-1) property in plugin.json. To avoid starting too many jobs, to output will be capped 6 versions.
 
 ### Example
 

--- a/e2e-version/action.yml
+++ b/e2e-version/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: false
     description: 'The maximum number of versions to resolve. Default is 6, 0 means no limit.'
     default: "6"
+  plugin-directory:
+    required: false
+    description: 'The directory where the plugin.json file is located. Default is `src`.'
+    default: src
 
 output:
   matrix:

--- a/e2e-version/index.js
+++ b/e2e-version/index.js
@@ -8,6 +8,7 @@ const SkipGrafanaDevImageInput = 'skip-grafana-dev-image';
 const VersionResolverTypeInput = 'version-resolver-type';
 const GrafanaDependencyInput = 'grafana-dependency';
 const LimitInput = 'limit';
+const PluginDirectoryInput = 'plugin-directory';
 const MatrixOutput = 'matrix';
 
 const VersionResolverTypes = {
@@ -137,7 +138,7 @@ async function getGrafanaStableMinorVersions() {
 }
 
 async function getPluginGrafanaDependencyFromPluginJson() {
-  const file = await fs.readFile(path.resolve(path.join(process.cwd(), 'src'), 'plugin.json'), 'utf8');
+  const file = await fs.readFile(path.resolve(path.join(core.getInput(PluginDirectoryInput)), 'plugin.json'), 'utf8');
   const json = JSON.parse(file);
   if (!json.dependencies.grafanaDependency) {
     throw new Error('Could not find plugin grafanaDependency');


### PR DESCRIPTION
Adds a `plugin-directory` input to support plugins in subdirectories (rather than src)

Required for https://github.com/grafana/plugin-ci-workflows/pull/119