### PR TITLE
fix: Disable immutable yarn installs

### DIFF
--- a/create-plugin-update/pm.sh
+++ b/create-plugin-update/pm.sh
@@ -18,7 +18,7 @@ install_pnpm_if_not_present() {
 # to determine the correct installation command
 # and the exec command to run create-plugin update
 if [ -f yarn.lock ]; then
-	install_deps=("yarn" "install")
+	install_deps=("yarn" "install" "--no-immutable")
 	create_plugin_update=("yarn" "create" "@grafana/plugin" "update")
 elif [ -f pnpm-lock.yaml ]; then
 	install_pnpm_if_not_present


### PR DESCRIPTION
This PR disables immutable yarn installs, allowing the update workflow to change the yarn.lock file if necessary. 

See [this issue](https://github.com/grafana/plugin-actions/issues/113) for additional context.

Fixes https://github.com/grafana/plugin-actions/issues/113