### PR TITLE
chore: change PR merge command to remove auto option

### DIFF
--- a/bundle-schema-types/action.yml
+++ b/bundle-schema-types/action.yml
@@ -123,7 +123,7 @@ runs:
         if [ -z "$PR_NUMBER" ]; then
           gh pr create --base main --head ${{ steps.create-branch.outputs.branch-name }} --title "Chore: Update plugin schema types" --body "$PR_BODY" --label "types-update"
           PR_NUMBER=$(gh pr list --base main --head ${{ steps.create-branch.outputs.branch-name }} --json number -q '.[0].number')
-          gh pr merge $PR_NUMBER
+          gh pr merge --disable-auto $PR_NUMBER
         fi
       shell: bash
 

--- a/bundle-schema-types/action.yml
+++ b/bundle-schema-types/action.yml
@@ -123,7 +123,7 @@ runs:
         if [ -z "$PR_NUMBER" ]; then
           gh pr create --base main --head ${{ steps.create-branch.outputs.branch-name }} --title "Chore: Update plugin schema types" --body "$PR_BODY" --label "types-update"
           PR_NUMBER=$(gh pr list --base main --head ${{ steps.create-branch.outputs.branch-name }} --json number -q '.[0].number')
-          gh pr merge --auto $PR_NUMBER
+          gh pr merge $PR_NUMBER
         fi
       shell: bash
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the pull request automation workflow. The change disables automatic merging of pull requests created for plugin schema type updates, requiring manual intervention for merging.