### PR TITLE
chore: ignore min and max items in TypeScript generation

### DIFF
--- a/bundle-schema-types/action.yml
+++ b/bundle-schema-types/action.yml
@@ -65,7 +65,7 @@ runs:
         jq '.title = "PluginSchema"' plugin.schema.json > plugin-schema-modified.json
         # Create the plugin-schema subdirectory if it doesn't exist
         mkdir -p ../plugin-extension-types/types/plugin-schema
-        npx -y --package=json-schema-to-typescript json2ts plugin-schema-modified.json > ../plugin-extension-types/types/plugin-schema/index.d.ts
+        npx -y --package=json-schema-to-typescript json2ts plugin-schema-modified.json --ignoreMinAndMaxItems > ../plugin-extension-types/types/plugin-schema/index.d.ts
         echo "Generated TypeScript types from plugin schema"
       shell: bash
 


### PR DESCRIPTION
This PR avoids errors like these https://github.com/grafana/grafana-com/actions/runs/18366979295/job/52321758099?pr=15161 as described in https://github.com/bcherny/json-schema-to-typescript?tab=readme-ov-file#options

***Before***
```ts
     /**
      * Array of plugin keywords. Used for search on grafana.com.
      *
      * @minItems 1
     */
    keywords: [string, ...string[]];
```
***After***
```ts
    /**
      * Array of plugin keywords. Used for search on grafana.com.
      *
      * @minItems 1
     */
    keywords: string[];
```