### PR TITLE
feat(bundle-size): prefilter for `MAIN_STATS_ARTIFACT`

### DIFF
--- a/bundle-size/action.yml
+++ b/bundle-size/action.yml
@@ -74,7 +74,7 @@ runs:
         MAIN_STATS_ARTIFACT: ${{ inputs.main-branch-stats-artifact }}
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        MAIN_STATS_RUN_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts --jq ".artifacts | map(select(.name == \"${MAIN_STATS_ARTIFACT}\")) | sort_by(.created_at) | reverse | .[0].workflow_run.id")
+        MAIN_STATS_RUN_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts?name=${MAIN_STATS_ARTIFACT} --jq ".artifacts | map(select(.name == \"${MAIN_STATS_ARTIFACT}\")) | sort_by(.created_at) | reverse | .[0].workflow_run.id")
         echo "run-id=${MAIN_STATS_RUN_ID}" >> $GITHUB_OUTPUT
       shell: bash
 


### PR DESCRIPTION
In our repo we create too many artifacts and the existing `gh api /repos/grafana/grafana-assistant-app/actions/artifacts` call would simply return a list which does not contain the artifact called `MAIN_STATS_ARTIFACT`.

This PR uses the API filter for the artifact name.