### PR TITLE
feat: support signing of private plugins

### DIFF
--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token"
     required: false
     default: ""
+  sign_root_urls:
+    description: "Root URLs for plugin signing"
+    required: false
+    default: ""
   grafana_token:
     description: "[deprecated] Grafana API Key to sign a plugin. Prefer `policy_token`."
     required: false
@@ -67,6 +71,7 @@ runs:
       uses: grafana/plugin-actions/package-plugin@main # zizmor: ignore[unpinned-uses]
       with:
         policy_token: ${{ inputs.policy_token }}
+        sign_root_urls: ${{ inputs.sign_root_urls }}
         node-version: "${{ inputs.node-version }}"
         go-version: "${{ inputs.go-version }}"
         backend-target: "${{ inputs.backend-target }}"

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Grafana access policy token. https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token"
     required: false
     default: ""
+  sign_root_urls:
+    description: "Root URLs for plugin signing"
+    required: false
+    default: ""
   go-version:
     description: "Version of go"
     required: false
@@ -100,7 +104,14 @@ runs:
       shell: bash
 
     - name: Sign plugin
-      run: ${{ github.action_path }}/pm.sh sign
+      run: |
+        if [ -n "${{ inputs.sign_root_urls }}" ]; then
+          echo "Signing private plugin including rootUrls"
+          ${{ github.action_path }}/pm.sh sign -- --rootUrls "${{ inputs.sign_root_urls }}"
+        else
+          echo "Signing public plugin"
+          ${{ github.action_path }}/pm.sh sign
+        fi
       shell: bash
       env:
         GRAFANA_ACCESS_POLICY_TOKEN: ${{ inputs.policy_token }}

--- a/package-plugin/pm.sh
+++ b/package-plugin/pm.sh
@@ -32,5 +32,5 @@ echo "Running '$1' with $pm..."
 if [ "$1" = "install" ]; then
 	"$pm" install
 else
-	"$pm" run "$1"
+	"$pm" run "$1" -- "${@:3}"
 fi


### PR DESCRIPTION
While it is documented, [how to sign a private plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin), the GitHub actions in this repo don't support this.

In order to allow users the supply the `rootUrls` argument to `npm run sign`, this PR introduces a new parameter `sign_root_urls`, which has to be passed to the `build-plugin` action, which finally passes it to the `package-plugin`, which actually does the signing.

Let me know, if there is an alternative, easier way to achieve this.

Fixes: #37 