### PR TITLE
feat!: make token required

### DIFF
--- a/create-plugin-update/README.md
+++ b/create-plugin-update/README.md
@@ -10,10 +10,13 @@ This GitHub Action automates the process of running `create-plugin update` withi
 
 ## Usage
 
+Detailed setup instructions can be found in the [Grafana developer portal](https://grafana.com/developers/plugin-tools/set-up/set-up-github#the-create-plugin-update-workflow).
+
 - Add a workflow to your Github repository as in the example below.
-- Set up the necessary secrets. As this action will push to and open a PR in the plugins repository make sure the token you supply has the correct privileges.
+- Set up the necessary secrets. As this action will push to and open a PR in the plugins repostory make sure the token you supply has the correct privileges.
 
 ## Workflow example
+
 <!-- x-release-please-start-version -->
 
 ```yaml
@@ -22,28 +25,26 @@ name: Create Plugin Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1 * *' # run once a month on the 1st day
-
-# To use the default github token with the following elevated permissions make sure to check:
-# **Allow GitHub Actions to create and approve pull requests** in https://github.com/USER_NAME/REPO_NAME/settings/actions.
-# Alternatively create a fine-grained personal access token for your repository with `contents: read and write` and `pull requests: read and write` and pass it to the action.
-
-permissions:
-  contents: write
-  pull-requests: write
+    - cron: "0 0 1 * *" # run once a month on the 1st day
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
+<<<<<<< Updated upstream
+=======
+        with:
+          token: ${{ secrets.GH_PAT_TOKEN }}
+>>>>>>> Stashed changes
 ```
+
 <!-- x-release-please-end-version -->
 
 ## Options
 
 The following options can be passed to this action:
 
-- `token`: A github token with write access to pull requests and content (defaults to `github.token`).
+- `token`: A github token with write access to pull requests and content (**required**).
 - `base`: The base branch to open the pull request against (defaults to `main`).
 - `node-version`: The version of node to use (defaults to `20`).

--- a/create-plugin-update/README.md
+++ b/create-plugin-update/README.md
@@ -42,6 +42,6 @@ jobs:
 
 The following options can be passed to this action:
 
-- `token`: A github token with write access to pull requests and content (**required**).
+- `token`: A github token with write access to `pull requests`, `content` and `workflows` (**required**).
 - `base`: The base branch to open the pull request against (defaults to `main`).
 - `node-version`: The version of node to use (defaults to `20`).

--- a/create-plugin-update/README.md
+++ b/create-plugin-update/README.md
@@ -13,7 +13,7 @@ This GitHub Action automates the process of running `create-plugin update` withi
 Detailed setup instructions can be found in the [Grafana developer portal](https://grafana.com/developers/plugin-tools/set-up/set-up-github#the-create-plugin-update-workflow).
 
 - Add a workflow to your Github repository as in the example below.
-- Set up the necessary secrets. As this action will push to and open a PR in the plugins repostory make sure the token you supply has the correct privileges.
+- Set up the necessary secrets. As this action will push to and open a PR in the plugins repostory create a fine-grained personal access token for your repository with `contents: read and write`, `pull requests: read and write` and `workflows: read and write` and pass it to the action.
 
 ## Workflow example
 
@@ -32,11 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
-<<<<<<< Updated upstream
-=======
         with:
           token: ${{ secrets.GH_PAT_TOKEN }}
->>>>>>> Stashed changes
 ```
 
 <!-- x-release-please-end-version -->

--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -4,8 +4,7 @@ description: "Runs create-plugin update within a Grafana plugin and opens a PR w
 inputs:
   token:
     description: "Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`."
-    required: false
-    default: "${{ github.token }}"
+    required: true
   base:
     description: "Sets the pull request base branch"
     required: false


### PR DESCRIPTION
This PR makes the cp-update workflow token input required to convince plugin developers to pass a PAT. We need this to resolve permission issues now create-plugin update can touch workflow files.

See associated [plugin-tools PR here](https://github.com/grafana/plugin-tools/pull/2281).