### PR TITLE
feat: pw report publish - cleanup git history

### DIFF
--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -88,6 +88,18 @@ runs:
         comment-tag: gf-playwright-test-results
         message: ${{ steps.generate-table.outputs.table }}
 
+    - name: Validate pages branch safety
+      shell: bash
+      run: |
+        if [[ "$PAGES_BRANCH" == "main" || "$PAGES_BRANCH" == "master" ]]; then
+          echo "ERROR: Cannot deploy to main/master branch with force_orphan - this would destroy repository history!"
+          echo "Please use a dedicated branch like 'gh-pages' for Pages deployment."
+          exit 1
+        fi
+        echo "✅ Pages branch '$PAGES_BRANCH' is safe for orphan deployment"
+      env:
+        PAGES_BRANCH: ${{ inputs.pages-branch }}
+
     - name: Push the new files to github pages
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
@@ -95,6 +107,7 @@ runs:
         github_token: ${{ inputs.github-token }}
         publish_dir: all-reports
         destination_dir: ${{ steps.timestampid.outputs.timestamp }}/${{ steps.set-initiator.outputs.job_initiator }}
+        force_orphan: true
 
 
     - name: Checkout code
@@ -119,7 +132,7 @@ runs:
           echo "No changes to commit"
         else
           git commit -m "Delete folders older than $RETENTION_DAYS days"
-          git push origin $PAGES_BRANCH
+          git push -f origin $PAGES_BRANCH
         fi
       env:
         RETENTION_DAYS: ${{ inputs.retention-days }}

--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -92,11 +92,10 @@ runs:
       shell: bash
       run: |
         if [[ "$PAGES_BRANCH" == "main" || "$PAGES_BRANCH" == "master" ]]; then
-          echo "ERROR: Cannot deploy to main/master branch with force_orphan - this would destroy repository history!"
+          echo "ERROR: Cannot deploy to main/master branch"
           echo "Please use a dedicated branch like 'gh-pages' for Pages deployment."
           exit 1
         fi
-        echo "✅ Pages branch '$PAGES_BRANCH' is safe for orphan deployment"
       env:
         PAGES_BRANCH: ${{ inputs.pages-branch }}
 


### PR DESCRIPTION
When Playwright reports are deployed to the gh-pages branch within the same repository, the repository size can grow significantly over time, leading to a bloated Git history. This is especially problematic when reports include trace viewers and screenshots.

This PR implements an orphan branch approach to solve this issue by deploying reports using orphan branches, which create fresh git branches with zero history for each deployment. This prevents accumulation of large commits over time.

[Example where this is used here: https://github.com/grafana/grafana-test-datasource/pull/18](https://github.com/grafana/grafana-test-datasource/pull/19)