### PR TITLE
fix: make sure create-plugin has access to npm dependencies

### DIFF
--- a/create-plugin-update/action.yml
+++ b/create-plugin-update/action.yml
@@ -55,6 +55,11 @@ runs:
         LATEST_VERSION: ${{ steps.get-latest-version.outputs.latest_version }}
         CONFIG_VERSION: ${{ steps.get-config-version.outputs.config_version }}
 
+    - name: Install dependencies
+      if: steps.compare-versions.outputs.update_needed == 'true'
+      run: ${{ github.action_path }}/pm.sh install
+      shell: bash
+
     - name: Create branch
       if: steps.compare-versions.outputs.update_needed == 'true'
       run: |


### PR DESCRIPTION
Testing out recent changes to this workflow and the instructions for setting permissions has highlighted an additional bug.

Create Plugin attempts to make use of prettier / eslint during updates if it exists on disk. However the cp-update workflow lacks an install step prior to running the update command. This PR addresses that so workflows can continue to run correctly.