### PR TITLE
fix: output version from pm-detect

### DIFF
--- a/package-manager-detect/action.yml
+++ b/package-manager-detect/action.yml
@@ -9,6 +9,9 @@ outputs:
   name:
     description: "The name of the package manager (e.g. npm, pnpm, yarn)"
     value: ${{ steps.detect-package-manager.outputs.name }}
+  version:
+    description: "The version of the package manager (e.g. 10.1.0, 10.1.1)"
+    value: ${{ steps.detect-package-manager.outputs.version }}
   lockFilePath:
     description: "The path to the lock file (e.g. package-lock.json, pnpm-lock.yaml, yarn.lock)"
     value: ${{ steps.detect-package-manager.outputs.lock-file-path }}

--- a/package-manager-detect/action.yml
+++ b/package-manager-detect/action.yml
@@ -54,6 +54,7 @@ runs:
 
         # Parse the JSON and extract individual values
         NAME=$(echo "$PM_OUTPUT" | jq -r '.name')
+        VERSION=$(echo "$PM_OUTPUT" | jq -r '.version')
         LOCK_FILE_PATH=$(echo "$PM_OUTPUT" | jq -r '.lockFilePath')
         AGENT=$(echo "$PM_OUTPUT" | jq -r '.agent')
         INSTALL_CMD=$(echo "$PM_OUTPUT" | jq -r '.install')
@@ -68,6 +69,7 @@ runs:
 
         # Set outputs
         echo "name=$NAME" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "lock-file-path=$LOCK_FILE_PATH" >> $GITHUB_OUTPUT
         echo "agent=$AGENT" >> $GITHUB_OUTPUT
         echo "install-cmd=$INSTALL_CMD" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The version that is collected by the npm package pm-detect is missing in the action output. This PR fixes that.