### PR TITLE
fix(wait-for-grafana): two-phase polling with smarter timeout handling

### DIFF
--- a/wait-for-grafana/README.md
+++ b/wait-for-grafana/README.md
@@ -26,7 +26,7 @@ The maximum time to wait for the server's TCP port to bind, in seconds. Default 
 
 This covers the window between the container starting and Grafana's HTTP listener becoming active. During this phase the action polls every 5 seconds. Once the port responds (with any status other than `000`), normal health polling begins using the `timeout` and `interval` values above.
 
-Newer or dev-preview Grafana images (e.g. Grafana 13, `dev-preview-react19`) can take longer to start on contested CI runners. Increasing this value gives them more time without affecting the health-check phase.
+On contested CI runners, Grafana's HTTP listener can take longer to bind than the default health-check window allows, regardless of Grafana version. Increasing this value gives the process more time to start without affecting the health-check phase.
 
 ## How to use?
 

--- a/wait-for-grafana/README.md
+++ b/wait-for-grafana/README.md
@@ -20,6 +20,14 @@ The maximum time to wait for the server to respond, in seconds. Default is `60`.
 
 The time to wait between each check, in seconds. Default is `0.5`.
 
+### `startupTimeout` (optional)
+
+The maximum time to wait for the server's TCP port to bind, in seconds. Default is `300`.
+
+This covers the window between the container starting and Grafana's HTTP listener becoming active. During this phase the action polls every 5 seconds. Once the port responds (with any status other than `000`), normal health polling begins using the `timeout` and `interval` values above.
+
+Newer or dev-preview Grafana images (e.g. Grafana 13, `dev-preview-react19`) can take longer to start on contested CI runners. Increasing this value gives them more time without affecting the health-check phase.
+
 ## How to use?
 
 You can use this action in your workflow to wait for a Grafana server to become available before running tests or other operations. Here's an example of how to use it:

--- a/wait-for-grafana/action.yml
+++ b/wait-for-grafana/action.yml
@@ -17,13 +17,18 @@ inputs:
     description: "Interval between checks in seconds"
     required: true
     default: "0.5"
+  startupTimeout:
+    description: "Seconds to wait for the TCP port to bind before health polling begins. Grafana 13 and dev-preview images can take longer to start on contested runners."
+    required: true
+    default: "300"
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/wait-for-grafana.sh "${GRAFANA_URL}" "${GRAFANA_RESPONSE_CODE}" "${GRAFANA_TIMEOUT}" "${GRAFANA_INTERVAL}"
+    - run: ${{ github.action_path }}/wait-for-grafana.sh "${GRAFANA_URL}" "${GRAFANA_RESPONSE_CODE}" "${GRAFANA_TIMEOUT}" "${GRAFANA_INTERVAL}" "${GRAFANA_STARTUP_TIMEOUT}"
       shell: bash
       env:
         GRAFANA_URL: ${{ inputs.url }}
         GRAFANA_RESPONSE_CODE: ${{ inputs.responseCode }}
         GRAFANA_TIMEOUT: ${{ inputs.timeout }}
         GRAFANA_INTERVAL: ${{ inputs.interval }}
+        GRAFANA_STARTUP_TIMEOUT: ${{ inputs.startupTimeout }}

--- a/wait-for-grafana/action.yml
+++ b/wait-for-grafana/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
     default: "0.5"
   startupTimeout:
-    description: "Seconds to wait for the TCP port to bind before health polling begins. Grafana 13 and dev-preview images can take longer to start on contested runners."
+    description: "Seconds to wait for the TCP port to bind before health polling begins. On contested CI runners, Grafana's HTTP listener can take longer to start than the default health-check window allows."
     required: true
     default: "300"
 runs:

--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -4,15 +4,42 @@ url="$1"
 expected_response_code="$2"
 timeout="$3"
 interval="$4"
+startup_timeout="$5"
 
 echo "Checking URL: $url"
 echo "Expected response code: $expected_response_code"
-echo "Timeout: $timeout seconds"
+echo "Startup timeout (TCP bind): $startup_timeout seconds"
+echo "Health timeout (after bind): $timeout seconds"
 echo "Interval: $interval seconds"
 
-end_time=$((SECONDS + timeout))
+# Phase 1: wait for TCP port to bind.
+# Status 000 means curl got ECONNREFUSED — the process isn't listening yet.
+# Poll every 5 seconds; hammering a closed port adds noise without benefit.
+startup_end=$((SECONDS + startup_timeout))
+port_bound=false
 
-while [ $SECONDS -lt $end_time ]; do
+while [ $SECONDS -lt $startup_end ]; do
+  response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "$url")
+  if [ "$response" != "000" ]; then
+    port_bound=true
+    break
+  fi
+  echo "Waiting for TCP bind. Current status: $response"
+  sleep 5
+done
+
+if [ "$port_bound" = false ]; then
+  echo "Startup timeout reached. Server TCP port did not bind within $startup_timeout seconds"
+  exit 1
+fi
+
+echo "TCP port bound. Waiting for server to respond with status code $expected_response_code..."
+
+# Phase 2: port is open, wait for a healthy response.
+# Fail fast on 4xx — indicates a URL misconfiguration, not a timing issue.
+health_end=$((SECONDS + timeout))
+
+while [ $SECONDS -lt $health_end ]; do
   response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
 
   if [ "$response" -eq "$expected_response_code" ]; then
@@ -20,9 +47,14 @@ while [ $SECONDS -lt $end_time ]; do
     exit 0
   fi
 
+  if [ "$response" -ge 400 ] && [ "$response" -lt 500 ]; then
+    echo "Server returned $response — likely a URL misconfiguration, failing fast"
+    exit 1
+  fi
+
   echo "Waiting for server to respond with status code $expected_response_code. Current status: $response"
   sleep "$interval"
 done
 
-echo "Timeout reached. Server did not respond with status code $expected_response_code within $timeout seconds"
+echo "Timeout reached. Server did not respond with status code $expected_response_code within $timeout seconds after TCP bind"
 exit 1

--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -4,7 +4,7 @@ url="$1"
 expected_response_code="$2"
 timeout="$3"
 interval="$4"
-startup_timeout="$5"
+startup_timeout="${5:-300}"
 
 echo "Checking URL: $url"
 echo "Expected response code: $expected_response_code"
@@ -13,18 +13,26 @@ echo "Health timeout (after bind): $timeout seconds"
 echo "Interval: $interval seconds"
 
 # Phase 1: wait for TCP port to bind.
-# Status 000 means curl got ECONNREFUSED — the process isn't listening yet.
-# Poll every 5 seconds; hammering a closed port adds noise without benefit.
+# curl exit code 7 = ECONNREFUSED: the process isn't listening yet, safe to keep waiting.
+# Any other non-zero exit code (e.g. 6 = DNS failure) indicates misconfiguration — fail fast.
 startup_end=$((SECONDS + startup_timeout))
 port_bound=false
 
 while [ $SECONDS -lt $startup_end ]; do
   response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "$url")
+  curl_exit=$?
+
+  if [ $curl_exit -ne 0 ] && [ $curl_exit -ne 7 ]; then
+    echo "curl failed with exit code $curl_exit (not a connection-refused error) — failing fast"
+    exit 1
+  fi
+
   if [ "$response" != "000" ]; then
     port_bound=true
     break
   fi
-  echo "Waiting for TCP bind. Current status: $response"
+
+  echo "Waiting for TCP bind (curl exit: $curl_exit). Current status: $response"
   sleep 5
 done
 
@@ -36,11 +44,13 @@ fi
 echo "TCP port bound. Waiting for server to respond with status code $expected_response_code..."
 
 # Phase 2: port is open, wait for a healthy response.
+# --connect-timeout and --max-time bound each curl call so a stalled connection
+# cannot outlast the health window.
 # Fail fast on 4xx — indicates a URL misconfiguration, not a timing issue.
 health_end=$((SECONDS + timeout))
 
 while [ $SECONDS -lt $health_end ]; do
-  response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+  response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 10 "$url")
 
   if [ "$response" -eq "$expected_response_code" ]; then
     echo "Server is up and responding with status code $expected_response_code"


### PR DESCRIPTION
## Problem

On contested CI runners, Grafana's HTTP listener can take longer than 60 seconds to bind its TCP port. The previous single-phase loop treated every non-200 status (including `000` — curl's code for ECONNREFUSED) the same, so a slow-starting container would time out the job before Grafana was ever ready.

This shows up as `wait-for-grafana` timing out with repeated `Current status: 000` lines. It is a runner resource contention issue, not specific to any Grafana version — confirmed seen on `grafana-enterprise@12.3.6` and `grafana-enterprise@13.0.0` and `dev-preview-react19`.

## Solution

Split polling into two phases:

**Phase 1 — TCP bind** (`startupTimeout`, default 300s)
- Polls every 5s while curl returns `000` (ECONNREFUSED, curl exit code 7)
- `000` with exit 7 specifically means the process isn't listening yet — always safe to keep waiting
- Fails fast on other non-zero curl exit codes (e.g. exit 6 = DNS failure) that won't self-resolve
- Long default (300s) covers worst-case runner contention without impacting fast-starting instances

**Phase 2 — Health check** (`timeout`, default 60s)
- Kicks in the moment the port responds with anything other than `000`
- Keeps the existing fast interval (default 0.5s) for snappy success detection
- Fails fast on `4xx` — a client error indicates URL misconfiguration, not a timing issue
- `--connect-timeout 2 --max-time 10` bounds each curl call so a stalled connection can't outlast the health window

## Backward compatibility

- Existing callers that don't pass `startupTimeout` get the 300s default
- The `timeout` and `interval` inputs are unchanged
- If Grafana starts quickly (the common case), Phase 1 exits immediately and Phase 2 behaves exactly as before
