### PR TITLE
fix(wait-for-grafana): remove Phase 1 fail-fast; any curl error is transient

### DIFF
--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -8,30 +8,32 @@ startup_timeout="${5:-300}"
 
 echo "Checking URL: $url"
 echo "Expected response code: $expected_response_code"
-echo "Startup timeout (TCP bind): $startup_timeout seconds"
-echo "Health timeout (after bind): $timeout seconds"
+echo "Startup timeout: $startup_timeout seconds"
+echo "Health timeout: $timeout seconds"
 echo "Interval: $interval seconds"
 
 # Phase 1: wait for the server to return any HTTP status.
-# Any curl error is treated as a transient startup condition — keep waiting.
-# This covers ECONNREFUSED, recv errors, connection resets, and any other
-# transient state that can occur while the process is starting up.
+# Any curl error (connection refused, recv error, etc.) is treated as
+# "not ready yet" — keep waiting until startup_timeout expires.
+# Note: this action targets localhost; persistent errors such as DNS
+# failures will eventually cause startup_timeout to expire naturally.
 startup_end=$((SECONDS + startup_timeout))
-port_bound=false
+server_up=false
 
 while [ $SECONDS -lt $startup_end ]; do
-  response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "$url")
+  response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 5 "$url")
+  curl_exit=$?
 
   if [ "$response" != "000" ]; then
-    port_bound=true
+    server_up=true
     break
   fi
 
-  echo "Waiting for server to start. Current status: $response"
+  echo "Waiting for server to start (curl exit: $curl_exit). Current status: $response"
   sleep 5
 done
 
-if [ "$port_bound" = false ]; then
+if [ "$server_up" = false ]; then
   echo "Startup timeout reached. Server did not respond within $startup_timeout seconds"
   exit 1
 fi

--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -13,8 +13,12 @@ echo "Health timeout (after bind): $timeout seconds"
 echo "Interval: $interval seconds"
 
 # Phase 1: wait for TCP port to bind.
-# curl exit code 7 = ECONNREFUSED: the process isn't listening yet, safe to keep waiting.
-# Any other non-zero exit code (e.g. 6 = DNS failure) indicates misconfiguration — fail fast.
+# Fail fast only on codes that indicate misconfiguration and will never self-resolve:
+#   exit 3 = URL malformed, exit 6 = could not resolve host.
+# All other non-zero exits are transient startup conditions — keep waiting:
+#   exit 7 = ECONNREFUSED (port not yet bound)
+#   exit 52 = got nothing (port open but server not yet responding)
+#   exit 56 = recv error (connection accepted then reset during startup)
 startup_end=$((SECONDS + startup_timeout))
 port_bound=false
 
@@ -22,8 +26,8 @@ while [ $SECONDS -lt $startup_end ]; do
   response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "$url")
   curl_exit=$?
 
-  if [ $curl_exit -ne 0 ] && [ $curl_exit -ne 7 ]; then
-    echo "curl failed with exit code $curl_exit (not a connection-refused error) — failing fast"
+  if [ $curl_exit -eq 3 ] || [ $curl_exit -eq 6 ]; then
+    echo "curl failed with exit code $curl_exit — misconfiguration error, failing fast"
     exit 1
   fi
 

--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -12,42 +12,33 @@ echo "Startup timeout (TCP bind): $startup_timeout seconds"
 echo "Health timeout (after bind): $timeout seconds"
 echo "Interval: $interval seconds"
 
-# Phase 1: wait for TCP port to bind.
-# Fail fast only on codes that indicate misconfiguration and will never self-resolve:
-#   exit 3 = URL malformed, exit 6 = could not resolve host.
-# All other non-zero exits are transient startup conditions — keep waiting:
-#   exit 7 = ECONNREFUSED (port not yet bound)
-#   exit 52 = got nothing (port open but server not yet responding)
-#   exit 56 = recv error (connection accepted then reset during startup)
+# Phase 1: wait for the server to return any HTTP status.
+# Any curl error is treated as a transient startup condition — keep waiting.
+# This covers ECONNREFUSED, recv errors, connection resets, and any other
+# transient state that can occur while the process is starting up.
 startup_end=$((SECONDS + startup_timeout))
 port_bound=false
 
 while [ $SECONDS -lt $startup_end ]; do
   response=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 "$url")
-  curl_exit=$?
-
-  if [ $curl_exit -eq 3 ] || [ $curl_exit -eq 6 ]; then
-    echo "curl failed with exit code $curl_exit — misconfiguration error, failing fast"
-    exit 1
-  fi
 
   if [ "$response" != "000" ]; then
     port_bound=true
     break
   fi
 
-  echo "Waiting for TCP bind (curl exit: $curl_exit). Current status: $response"
+  echo "Waiting for server to start. Current status: $response"
   sleep 5
 done
 
 if [ "$port_bound" = false ]; then
-  echo "Startup timeout reached. Server TCP port did not bind within $startup_timeout seconds"
+  echo "Startup timeout reached. Server did not respond within $startup_timeout seconds"
   exit 1
 fi
 
-echo "TCP port bound. Waiting for server to respond with status code $expected_response_code..."
+echo "Server is responding. Waiting for status code $expected_response_code..."
 
-# Phase 2: port is open, wait for a healthy response.
+# Phase 2: server is up, wait for a healthy response.
 # --connect-timeout and --max-time bound each curl call so a stalled connection
 # cannot outlast the health window.
 # Fail fast on 4xx — indicates a URL misconfiguration, not a timing issue.
@@ -70,5 +61,5 @@ while [ $SECONDS -lt $health_end ]; do
   sleep "$interval"
 done
 
-echo "Timeout reached. Server did not respond with status code $expected_response_code within $timeout seconds after TCP bind"
+echo "Timeout reached. Server did not respond with status code $expected_response_code within $timeout seconds"
 exit 1


### PR DESCRIPTION
## Problem

After #213 merged, a CI run on `grafana-cmab-app` hit this failure:

```
curl failed with exit code 56 (not a connection-refused error) — failing fast
```

Exit code 56 is `CURLE_RECV_ERROR`: the TCP connection was accepted but reset before HTTP headers were sent — a valid transient startup state. The exit-code allowlist in #213 was too narrow, and any attempt to enumerate "safe" vs "unsafe" curl exit codes is fragile: we can't predict every transient error Grafana's startup can produce.

## Fix

Remove the fail-fast check from Phase 1 entirely. Any curl error during startup is treated as "not ready yet — keep waiting." This is safe because the action is always pointed at a localhost URL; there is no transient error that won't eventually resolve once the process finishes starting.

Phase 2 retains its 4xx fail-fast, where a bad HTTP response genuinely indicates URL misconfiguration (the server is up and actively rejecting the request).
