### PR TITLE
feat: build plugin docs as part of package-plugin when docsPath is set

### DIFF
--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -68,7 +68,7 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@main # zizmor: ignore[unpinned-uses]
+      uses: grafana/plugin-actions/package-plugin@eriksundell/plugin-docs-build-step # zizmor: ignore[unpinned-uses]
       with:
         policy_token: ${{ inputs.policy_token }}
         sign_root_urls: ${{ inputs.sign_root_urls }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -68,7 +68,7 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@eriksundell/plugin-docs-build-step # zizmor: ignore[unpinned-uses]
+      uses: grafana/plugin-actions/package-plugin@main # zizmor: ignore[unpinned-uses]
       with:
         policy_token: ${{ inputs.policy_token }}
         sign_root_urls: ${{ inputs.sign_root_urls }}

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -73,6 +73,14 @@ runs:
       run: ${{ github.action_path }}/pm.sh build
       shell: bash
 
+    - name: Build plugin documentation
+      shell: bash
+      run: |
+        DOCS_PATH=$(cat dist/plugin.json | jq -r '.docsPath // empty')
+        if [ -n "$DOCS_PATH" ]; then
+          npx --yes @grafana/plugin-docs-cli build
+        fi
+
     - name: Check for backend
       id: check-for-backend
       run: |

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -36,20 +36,20 @@ inputs:
     type: choice
     description: "Backend target for the plugin backend build"
     options:
-        - build:backend
-        - build:darwin
-        - build:darwinARM64
-        - build:debug
-        - build:debugDarwinAMD64
-        - build:debugDarwinARM64
-        - build:debugLinuxAMD64
-        - build:debugLinuxARM64
-        - build:debugWindowsAMD64
-        - build:linux
-        - build:linuxARM
-        - build:linuxARM64
-        - build:windows
-        - buildAll
+      - build:backend
+      - build:darwin
+      - build:darwinARM64
+      - build:debug
+      - build:debugDarwinAMD64
+      - build:debugDarwinARM64
+      - build:debugLinuxAMD64
+      - build:debugLinuxARM64
+      - build:debugWindowsAMD64
+      - build:linux
+      - build:linuxARM
+      - build:linuxARM64
+      - build:windows
+      - buildAll
     required: false
     default: "buildAll"
 
@@ -78,7 +78,7 @@ runs:
       run: |
         DOCS_PATH=$(cat dist/plugin.json | jq -r '.docsPath // empty')
         if [ -n "$DOCS_PATH" ]; then
-          npx --yes @grafana/plugin-docs-cli build
+          npx --yes @grafana/plugin-docs-cli@0.0.11-canary.2636.26226198477.0 build
         fi
 
     - name: Check for backend

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -36,20 +36,20 @@ inputs:
     type: choice
     description: "Backend target for the plugin backend build"
     options:
-      - build:backend
-      - build:darwin
-      - build:darwinARM64
-      - build:debug
-      - build:debugDarwinAMD64
-      - build:debugDarwinARM64
-      - build:debugLinuxAMD64
-      - build:debugLinuxARM64
-      - build:debugWindowsAMD64
-      - build:linux
-      - build:linuxARM
-      - build:linuxARM64
-      - build:windows
-      - buildAll
+        - build:backend
+        - build:darwin
+        - build:darwinARM64
+        - build:debug
+        - build:debugDarwinAMD64
+        - build:debugDarwinARM64
+        - build:debugLinuxAMD64
+        - build:debugLinuxARM64
+        - build:debugWindowsAMD64
+        - build:linux
+        - build:linuxARM
+        - build:linuxARM64
+        - build:windows
+        - buildAll
     required: false
     default: "buildAll"
 

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -78,7 +78,7 @@ runs:
       run: |
         DOCS_PATH=$(cat dist/plugin.json | jq -r '.docsPath // empty')
         if [ -n "$DOCS_PATH" ]; then
-          npx --yes @grafana/plugin-docs-cli@0.0.11-canary.2636.26226198477.0 build
+          npx --yes @grafana/plugin-docs-cli@0.2.0 build
         fi
 
     - name: Check for backend

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -76,6 +76,8 @@ runs:
     - name: Build plugin documentation
       shell: bash
       run: |
+        sudo apt-get install jq
+
         DOCS_PATH=$(cat dist/plugin.json | jq -r '.docsPath // empty')
         if [ -n "$DOCS_PATH" ]; then
           npx --yes @grafana/plugin-docs-cli@0.2.0 build


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a "Build plugin documentation" step to `package-plugin` that runs `npx @grafana/plugin-docs-cli build` when `docsPath` is set in `dist/plugin.json`. The step generates `dist/docs/manifest.json` and copies the markdown and images, so multi-page docs ride along in the resulting ZIP and reach the CDN through the existing pipeline.

Plugins without `docsPath` are unaffected - the bash conditional short-circuits before invoking the CLI.

**Which issue(s) this PR fixes**:

No issue - part of the multi-page plugin docs initiative.

**Special notes for your reviewer**:

