### PR TITLE
chore: migrate codeowners to @grafana/grafana-catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,9 @@
 # these will be requested for review when someone opens a pull request.
 
 * @grafana/grafana-catalog
+
+# Frontend-platform-owned actions (based on contribution history)
+/bundle-schema-types/  @grafana/grafana-frontend-platform
+/bundle-size/          @grafana/grafana-frontend-platform
+/bundle-types/         @grafana/grafana-frontend-platform
+/create-plugin-update/ @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 
-* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
+* @grafana/grafana-catalog


### PR DESCRIPTION
## Summary

Migrate ownership from the three retiring plugins-platform handles to the new `@grafana/grafana-catalog` handle, with a surgical split for directories where the contribution history clearly belongs to frontend-platform.

**Default owner:** `@grafana/grafana-catalog` (replaces `@grafana/plugins-platform`, `@grafana/plugins-platform-frontend`, `@grafana/plugins-platform-backend`)

**Frontend-platform overrides** — based on git contribution history, these four directories are dominated by Jack Westbrook / Hugo Häggmark and route to `@grafana/grafana-frontend-platform`:

- `/bundle-schema-types/` — Hugo Häggmark is the only human contributor
- `/bundle-size/` — Jack Westbrook is the top human contributor
- `/bundle-types/` — Jack Westbrook is the top human contributor
- `/create-plugin-update/` — Jack Westbrook is the top human contributor (7 commits)

`/package-manager-detect/` was considered but stays under the default `@grafana/grafana-catalog` per repo-owner judgment.

Tracking issue: grafana/grafana-catalog-team#870

## Test plan
- [x] CI passes
- [x] CODEOWNERS validation succeeds