### PR TITLE
chore: harden permisions in bundle-stats readme example

### DIFF
--- a/bundle-size/README.md
+++ b/bundle-size/README.md
@@ -27,7 +27,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: read
 


### PR DESCRIPTION
Update permissions in bundle-stats readme example to using contents: read;