### PR TITLE
chore(playwright-gh-pages): narrow down permissions

### DIFF
--- a/playwright-gh-pages/README.md
+++ b/playwright-gh-pages/README.md
@@ -38,15 +38,19 @@ If you’re already using GitHub Pages for other content, ensure that it does no
 
 ## GitHub Pages Visibility
 
-By default, all GitHub Pages sites are publicly accessible on the Internet. However, GitHub Enterprise customers can restrict access by configuring access control for private and internal repositories. This allows greater flexibility in managing who can view your Pages site. For more details, refer to the official GitHub [documentation](https://docs.github.com/en/enterprise-cloud@latest/pages/getting-started-with-github-pages/changing-the-visibility-of-your-github-pages-site#about-access-control-for-github-pages-sites).
+By default, all GitHub Pages sites are publicly accessible on the Internet. Published Playwright reports can include HTML output, screenshots, traces, and internal URLs, so review the contents before enabling this workflow for sensitive repositories. GitHub Enterprise customers can restrict access by configuring access control for private and internal repositories. For more details, refer to the official GitHub [documentation](https://docs.github.com/en/enterprise-cloud@latest/pages/getting-started-with-github-pages/changing-the-visibility-of-your-github-pages-site#about-access-control-for-github-pages-sites).
 
 ## Permissions Needed
 
-To use these actions, you need to set up the necessary permissions:
+Use job-scoped permissions instead of granting write access to the entire workflow:
 
-- `contents: write`: This permission is needed to push changes to the repository, such as updating the GitHub Pages branch with the latest test reports.
-- `id-token: write`: This permission is required for authentication purposes when interacting with GitHub APIs.
-- `pull-requests: write`: This permission allows the action to create and update pull requests with comments containing the test results and links to the reports.
+- Set `contents: read` at the workflow level so test jobs can check out the repository.
+- Add `contents: write` only to the job that publishes reports to the Pages branch.
+- Add `pull-requests: write` only if you want `deploy-report-pages` to manage a pull request comment. This permission is not needed when `pr-comment-summary: false`.
+
+The `playwright-gh-pages` actions do not use OIDC, so `id-token: write` is not required for report publishing.
+
+If your workflow runs on `pull_request`, remember that pull requests from forks receive a read-only `GITHUB_TOKEN`. In that case the publish job may be unable to push the Pages branch or update the PR comment. Avoid switching these examples to `pull_request_target` just to get a write-capable token unless you have separately reviewed the security implications of running untrusted code with elevated permissions.
 
 ## Workflow usage
 
@@ -64,9 +68,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 jobs:
   resolve-versions:
@@ -132,13 +134,15 @@ jobs:
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main
         if: ${{ (always() && !cancelled()) }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           test-outcome: ${{ steps.run-tests.outcome }}
 
   deploy-pages:
-    if: ${{ (always() && !cancelled()) }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     needs: [playwright-tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -163,9 +167,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 jobs:
   e2e:
@@ -207,9 +209,12 @@ jobs:
       # repeat steps but for another Grafana version if necessary
 
   deploy-pages:
-    if: ${{ (always() && !cancelled()) }}
-    needs: [playwright-tests]
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    needs: [e2e]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -223,3 +228,9 @@ jobs:
 ## Inputs
 
 For details on what the available inputs for the Actions, refer to the [README](./deploy-report-pages/README.md) of `deploy-report-pages` and the [README](./upload-report-artifacts/README.md) of `upload-report-artifacts`
+
+If you want to skip publishing for forked pull requests while still allowing scheduled runs, pushes, and same-repository pull requests, use this condition on the publish job:
+
+```yaml
+if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+```

--- a/playwright-gh-pages/deploy-report-pages/README.md
+++ b/playwright-gh-pages/deploy-report-pages/README.md
@@ -4,14 +4,14 @@ This GitHub Action automates the process of publishing test artifacts to GitHub 
 
 ## Usage
 
-See full blown examples [here](../README.txt).
+See full blown examples [here](../README.md).
 
 ## Inputs
 
 | Input Name           | Description                                                                    | Required | Default                  |
 | -------------------- | ------------------------------------------------------------------------------ | -------- | ------------------------ |
-| `github-token`       | Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`. | Yes      | N/A                      |
+| `github-token`       | Token for the repository. Pass `${{ secrets.GITHUB_TOKEN }}` from the publish job. | Yes      | N/A                      |
 | `retention-days`     | Number of days to retain the reports.                                          | Yes      | 30                       |
-| `pr-comment-summary` | Whether to comment the PR with the test results.                               | Yes      | true                     |
+| `pr-comment-summary` | Whether to manage a PR comment with the test results. Set this to `false` if you do not want the action to create or delete PR comments. | Yes      | true                     |
 | `artifact-pattern`   | Pattern to match the artifacts.                                                | Yes      | `gf-playwright-report-*` |
 | `pages-branch`       | Branch to deploy the reports to.                                               | Yes      | `gh-pages`               |

--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -3,7 +3,7 @@ description: 'Deploys test artifacts to GitHub Pages and comments on the PR with
 
 inputs:
   github-token:
-    description: 'Token for the repository. Can be passed in using `${{ secrets.GITHUB_TOKEN }}`.'
+    description: 'Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.'
     required: true
   retention-days:
     description: 'Number of days to retain the reports. Default is 30.'

--- a/playwright-gh-pages/deploy-report-pages/action.yml
+++ b/playwright-gh-pages/deploy-report-pages/action.yml
@@ -3,7 +3,7 @@ description: 'Deploys test artifacts to GitHub Pages and comments on the PR with
 
 inputs:
   github-token:
-    description: 'Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.'
+    description: 'Token for the repository. Can be passed in using `${{ secrets.GITHUB_TOKEN }}`.'
     required: true
   retention-days:
     description: 'Number of days to retain the reports. Default is 30.'
@@ -34,7 +34,7 @@ runs:
 
     - name: Delete any existing comment
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      if: ${{ github.event.number != null }}
+      if: ${{ inputs.pr-comment-summary == 'true' && github.event.number != null }}
       with:
         comment-tag: gf-playwright-test-results
         mode: delete

--- a/playwright-gh-pages/upload-report-artifacts/README.md
+++ b/playwright-gh-pages/upload-report-artifacts/README.md
@@ -4,17 +4,18 @@ This GitHub Action automates the process of uploading test reports and summaries
 
 ## Usage
 
-See full blown examples [here](../README.txt).
+See full blown examples [here](../README.md).
 
 ## Inputs
 
 | Input Name                  | Description                                                                                                                     | Required | Default                               |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
-| `github-token`              | Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.                                                  | Yes      | `${{ github.token }}`                 |
-| `test-outcome`              | Outcome of the test step. For example `{{ steps.run-tests.outcome }}`.                                                          | Yes      | N/A                                   |
-| `grafana-image`             | Grafana image used in the test. Default is `{{ matrix.GRAFANA_IMAGE.NAME }}`.                                                   | Yes      | `${{ matrix.GRAFANA_IMAGE.NAME }}`    |
-| `grafana-version`           | Grafana version used in the test. Default is `{{ matrix.GRAFANA_IMAGE.VERSION }}`.                                              | Yes      | `${{ matrix.GRAFANA_IMAGE.VERSION }}` |
+| `github-token`              | Deprecated and unused. This input is ignored and normally should not be set explicitly.                                         | No       | `${{ github.token }}`                 |
+| `test-outcome`              | Outcome of the test step. For example `${{ steps.run-tests.outcome }}`.                                                         | Yes      | N/A                                   |
+| `grafana-image`             | Grafana image used in the test. Default is `${{ matrix.GRAFANA_IMAGE.NAME }}`.                                                  | Yes      | `${{ matrix.GRAFANA_IMAGE.NAME }}`    |
+| `grafana-version`           | Grafana version used in the test. Default is `${{ matrix.GRAFANA_IMAGE.VERSION }}`.                                             | Yes      | `${{ matrix.GRAFANA_IMAGE.VERSION }}` |
 | `artifact-prefix`           | Pattern to prefix the artifact with. Default is "gf-playwright-report-".                                                        | No       | `gf-playwright-report-`               |
+| `upload-report`             | Whether to upload the report directory even when tests succeed.                                                                  | Yes      | `true`                                |
 | `upload-successful-reports` | Whether to upload the report if all tests were successful.                                                                      | No       | `false`                               |
 | `report-dir`                | Directory in which the report is stored. Default is "playwright-report".                                                        | Yes      | `playwright-report`                   |
 | `plugin-name`               | Name of the plugin being tested. Useful in for example mono-repos when multiple plugins are tested generating multiple reports. | No       | N/A                                   |

--- a/playwright-gh-pages/upload-report-artifacts/action.yml
+++ b/playwright-gh-pages/upload-report-artifacts/action.yml
@@ -8,18 +8,18 @@ outputs:
 
 inputs:
   github-token:
-    description: "Deprecated and unused. This input is ignored and will be removed in a future major release."
-    required: false
+    description: "Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`."
+    required: true
     default: ${{ github.token }}
   test-outcome:
-    description: "Outcome of the test step. For example `${{ steps.run-tests.outcome }}`."
+    description: "Outcome of the test step. For example `{{ steps.run-tests.outcome }}`."
     required: true
   grafana-image:
-    description: "Grafana image used in the test. Default is `${{ matrix.GRAFANA_IMAGE.NAME }}`."
+    description: "Grafana image used in the test. Default is `{{ matrix.GRAFANA_IMAGE.NAME }}`."
     default: ${{ matrix.GRAFANA_IMAGE.NAME }}
     required: true
   grafana-version:
-    description: "Grafana version used in the test. Default is `${{ matrix.GRAFANA_IMAGE.VERSION }}`."
+    description: "Grafana version used in the test. Default is `{{ matrix.GRAFANA_IMAGE.VERSION }}`."
     default: ${{ matrix.GRAFANA_IMAGE.VERSION }}
     required: true
   artifact-prefix:

--- a/playwright-gh-pages/upload-report-artifacts/action.yml
+++ b/playwright-gh-pages/upload-report-artifacts/action.yml
@@ -8,18 +8,18 @@ outputs:
 
 inputs:
   github-token:
-    description: "Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`."
-    required: true
+    description: "Deprecated and unused. This input is ignored and will be removed in a future major release."
+    required: false
     default: ${{ github.token }}
   test-outcome:
-    description: "Outcome of the test step. For example `{{ steps.run-tests.outcome }}`."
+    description: "Outcome of the test step. For example `${{ steps.run-tests.outcome }}`."
     required: true
   grafana-image:
-    description: "Grafana image used in the test. Default is `{{ matrix.GRAFANA_IMAGE.NAME }}`."
+    description: "Grafana image used in the test. Default is `${{ matrix.GRAFANA_IMAGE.NAME }}`."
     default: ${{ matrix.GRAFANA_IMAGE.NAME }}
     required: true
   grafana-version:
-    description: "Grafana version used in the test. Default is `{{ matrix.GRAFANA_IMAGE.VERSION }}`."
+    description: "Grafana version used in the test. Default is `${{ matrix.GRAFANA_IMAGE.VERSION }}`."
     default: ${{ matrix.GRAFANA_IMAGE.VERSION }}
     required: true
   artifact-prefix:


### PR DESCRIPTION
Narrow the documented playwright-gh-pages permissions and make PR comment writes truly optional when comment publishing is disabled.