### PR TITLE
chore(release-please): migrate token generation to GATB

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,24 +20,13 @@ jobs:
       pull-requests: write # Needed to create release PRs
       id-token: write
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        if: ${{ env.IS_FORK == 'false' }}
-        uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
-        with:
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
-
       - name: Generate GitHub token
         id: generate-github-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         if: ${{ env.IS_FORK == 'false' }}
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: grafana-plugins-platform-bot
+          permission_set: release-please
 
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/release-please.yml` off the long-lived `grafana-plugins-platform-bot` token (Vault `get-vault-secrets` + `actions/create-github-app-token`) onto the short-lived **GATB** (GitHub App Token Broker) flow via `grafana/shared-workflows/actions/create-github-app-token`.

Why: per the [plugins-platform GATB migration](https://github.com/grafana/grafana-catalog-team/blob/main/docs/plugins-ci-github-actions/070-gatb-migration.md), the long-lived bot token will be revoked. Workflows using it must switch to GATB or stop working.

What changes:
- Drop the `Get secrets from Vault` step (no more raw app-id / private-key).
- Replace `actions/create-github-app-token@v2.1.4` with `grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.2.3`, asking for the `release-please` permission set.
- Downstream `release-please-action` and `github-script` tagging steps are untouched — they keep reading `steps.generate-github-token.outputs.token`.

Same shape as the existing `grafana/levitate` migration ([reference workflow](https://github.com/grafana/levitate/blob/main/.github/workflows/release-please.yml)).

## Companion PR (must merge first)

[grafana/deployment_tools#592468](https://github.com/grafana/deployment_tools/pull/592468) — adds the matching GATB config at `terraform/repositories/plugin-actions/github-app-configs/config.yaml`. Without it merged **and `atlantis apply`'d**, this workflow will 403 / hit a "role not found" error on the next release-please run.

Order:
1. Merge deployment_tools PR (via `atlantis apply`).
2. Merge this PR.

`plugin-actions` is already in `plugins-platform-bot-users.txt`, so no IT ticket needed.

## Test plan

- [ ] After deployment_tools PR is applied + this PR merged, next push to `main` triggers `release-please` successfully (token issued, release PR opens / updates).
- [ ] On a real release (`releases_created == 'true'`), the `tag major and minor versions` step runs and moves the major/minor tags.