### PR TITLE
fix(wait-for-grafana): lower startupTimeout default from 300s to 60s

### DIFF
--- a/wait-for-grafana/README.md
+++ b/wait-for-grafana/README.md
@@ -22,11 +22,11 @@ The time to wait between each check, in seconds. Default is `0.5`.
 
 ### `startupTimeout` (optional)
 
-The maximum time to wait for the server's TCP port to bind, in seconds. Default is `300`.
+The maximum time to wait for the server's TCP port to bind, in seconds. Default is `60`.
 
 This covers the window between the container starting and Grafana's HTTP listener becoming active. During this phase the action polls every 5 seconds. Once the port responds (with any status other than `000`), normal health polling begins using the `timeout` and `interval` values above.
 
-On contested CI runners, Grafana's HTTP listener can take longer to bind than the default health-check window allows, regardless of Grafana version. Increasing this value gives the process more time to start without affecting the health-check phase.
+Raise this value only if Grafana genuinely takes longer than the default to start. A long default delays diagnosis of startup *crashes* (for example, a provisioning deadlock that prevents the HTTP listener from ever binding), since the action can only observe `000` and cannot distinguish "still booting" from "dead before booting." Pair this action with a separate diagnostic step that dumps container logs on failure to recover the real signal.
 
 ## How to use?
 

--- a/wait-for-grafana/action.yml
+++ b/wait-for-grafana/action.yml
@@ -18,9 +18,9 @@ inputs:
     required: true
     default: "0.5"
   startupTimeout:
-    description: "Seconds to wait for the TCP port to bind before health polling begins. On contested CI runners, Grafana's HTTP listener can take longer to start than the default health-check window allows."
+    description: "Seconds to wait for the TCP port to bind before health polling begins. Raise this only if Grafana genuinely takes longer than the default to start — a long default delays diagnosis of startup crashes (e.g. provisioning deadlocks), which never recover no matter how long we wait."
     required: true
-    default: "300"
+    default: "60"
 runs:
   using: "composite"
   steps:

--- a/wait-for-grafana/wait-for-grafana.sh
+++ b/wait-for-grafana/wait-for-grafana.sh
@@ -4,7 +4,7 @@ url="$1"
 expected_response_code="$2"
 timeout="$3"
 interval="$4"
-startup_timeout="${5:-300}"
+startup_timeout="${5:-60}"
 
 echo "Checking URL: $url"
 echo "Expected response code: $expected_response_code"


### PR DESCRIPTION
## Summary

Lowers the `startupTimeout` default in `wait-for-grafana` from **300 seconds back to 60**, restoring v1.0.2's fail-fast behaviour for startup crash scenarios while keeping the two-phase split available for repos with a genuine slow-start need.

The two-phase polling introduced in v1.0.3 (#213) was based on the hypothesis that Playwright matrix flakes are slow-but-alive Grafana startups on contested runners. That diagnosis was incomplete. The class of failure that's actually been hitting plugin repos in the matrix is a **Grafana startup crash** — the SQLite write lock is held by legacy provisioning while the Advisor's `checktyperegisterer` runner tries to POST to the unified resource server, causing a self-deadlock that prevents the HTTP listener from ever binding.

- Upstream Grafana bug: [grafana/grafana#122993](https://github.com/grafana/grafana/issues/122993)
- Upstream fix (lands in 13.0.2): [grafana/grafana#123034](https://github.com/grafana/grafana/pull/123034)
- Workaround applied in the matrix: [grafana/logs-drilldown#1886](https://github.com/grafana/logs-drilldown/pull/1886), [grafana/grafana-adaptivelogs-app#1534](https://github.com/grafana/grafana-adaptivelogs-app/pull/1534)

In that scenario the v1.0.3 default makes the failure **5× slower** to diagnose than v1.0.2 was: the action waits 5 minutes observing only `Current status: 000` before timing out, during which the operator has no signal at all. `wait-for-grafana` is structurally unable to distinguish "still booting" from "dead before booting" — both produce the same ECONNREFUSED.

## Why not revert the two-phase logic entirely?

The Phase 1 / Phase 2 split (TCP-bind vs health endpoint) is still useful in the slow-but-alive case it was designed for; only the default was too generous. Repos that hit genuine slow-start situations can still opt into a higher value explicitly:

```yaml
- uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.5
  with:
    startupTimeout: 180  # explicit opt-in for known-slow environments
```

## Follow-up

A separate PR will propose a sibling `grafana-startup-logs` action that dumps `docker compose ps` + a filtered, secret-masked tail of Grafana's own logs when `wait-for-grafana` fails. That is the right place to surface the real signal — at the diagnostic layer, not by waiting longer at the polling layer.

## Test plan

- [x] Action.yml + script + README all updated consistently
- [x] Rebased onto current `main` (post-1.0.4 release) with no functional conflicts
- [ ] CI: the existing wait-for-grafana matrix test (if any) still passes with the new default
- [ ] Consumers that previously relied on the implicit 300s window can override explicitly via `startupTimeout:` input
