### PR TITLE
fix: harden package manager config

### DIFF
--- a/e2e-version/.npmrc
+++ b/e2e-version/.npmrc
@@ -1,0 +1,4 @@
+allow-git=none
+ignore-scripts=true
+min-release-age=3
+save-exact=true

--- a/e2e-version/.npmrc
+++ b/e2e-version/.npmrc
@@ -1,4 +1,2 @@
-allow-git=none
 ignore-scripts=true
-min-release-age=3
 save-exact=true

--- a/e2e-version/.npmrc
+++ b/e2e-version/.npmrc
@@ -1,2 +1,4 @@
 ignore-scripts=true
 save-exact=true
+allow-git=none
+min-release-age=3

--- a/e2e-version/package.json
+++ b/e2e-version/package.json
@@ -1,6 +1,7 @@
 {
   "name": "grafana-e2e-versions",
   "version": "0.0.1",
+  "packageManager": "npm@11.16.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Draft canary PR generated from the `security-hardening` skill prototype in grafana/ai-kit#585.

This applies deterministic safe npm hardening for package roots where npm is unambiguous from the existing lockfile:

- `packageManager: "npm@11.16.0"` — exact pin to the npm registry `latest` dist-tag checked on 2026-05-28
- `ignore-scripts=true`
- `save-exact=true`
- `allow-git=none`
- `min-release-age=3`

## Validation

- Ran `security_hardening.py fix --modules package-management --safe-only --apply`
- Re-ran `security_hardening.py detect --modules package-management`
- Confirmed there are `0` remaining package-management findings in this canary checkout

## Notes

This intentionally does not migrate npm to pnpm. pnpm may be a valid stronger hardening path, but it changes lockfiles/install commands and should be a separate owner-reviewed migration.
