### PR TITLE
fix: pin pm-detect

### DIFF
--- a/package-manager-detect/action.yml
+++ b/package-manager-detect/action.yml
@@ -53,7 +53,7 @@ runs:
       id: detect-package-manager
       run: |
         # Run pm-detect and capture the JSON output
-        PM_OUTPUT=$(npx -y pm-detect --working-dir "$WORKING_DIRECTORY")
+        PM_OUTPUT=$(npx -y pm-detect@0.6.0 --working-dir "$WORKING_DIRECTORY")
 
         # Parse the JSON and extract individual values
         NAME=$(echo "$PM_OUTPUT" | jq -r '.name')


### PR DESCRIPTION
pins the version of [pm-detect](https://www.npmjs.com/package/pm-detect) used by the npx command