### PR TITLE
fix(build-plugin): use GitHub API to create signed changelog commit

### DIFF
--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -72,7 +72,7 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@main # zizmor: ignore[unpinned-uses]
+      uses: grafana/plugin-actions/package-plugin@fix/signed-commits-build-plugin # zizmor: ignore[unpinned-uses]
       with:
         policy_token: ${{ inputs.policy_token }}
         sign_root_urls: ${{ inputs.sign_root_urls }}

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -133,19 +133,37 @@ runs:
 
     - name: Commit updated changelog
       if: ${{ inputs.use_changelog_generator == 'true' }}
-      run: |
-        git add CHANGELOG.md
-
-        git config --local user.name grafana-plugins-platform-bot[bot]
-        git config --local user.email 144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com
-
-        git commit -m "docs: update changelog for ${PLUGIN_VERSION} [skip ci]"
-
-        git push origin HEAD:${DEFAULT_BRANCH}
       shell: bash
       env:
+        GH_TOKEN: ${{ inputs.token }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         PLUGIN_VERSION: ${{ steps.package-plugin.outputs.plugin-version }}
+      run: |
+        HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')
+        FILE_CONTENTS=$(base64 -w 0 CHANGELOG.md)
+
+        jq -n \
+          --arg repo "$GITHUB_REPOSITORY" \
+          --arg branch "$DEFAULT_BRANCH" \
+          --arg message "docs: update changelog for ${PLUGIN_VERSION} [skip ci]" \
+          --arg contents "$FILE_CONTENTS" \
+          --arg headOid "$HEAD_SHA" \
+          '{
+            query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }",
+            variables: {
+              input: {
+                branch: {
+                  repositoryNameWithOwner: $repo,
+                  branchName: $branch
+                },
+                message: { headline: $message },
+                fileChanges: {
+                  additions: [{ path: "CHANGELOG.md", contents: $contents }]
+                },
+                expectedHeadOid: $headOid
+              }
+            }
+          }' | gh api graphql --input -
 
     - name: Create Github release
       uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -58,10 +58,6 @@ inputs:
     description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
     required: false
     default: "false"
-  skip_plugin_validator:
-    description: "Skip the plugin validation step"
-    required: false
-    default: "false"
   use_changelog_generator:
     description: "Whether to generate a changelog for the plugin"
     required: false
@@ -72,14 +68,13 @@ runs:
   steps:
     - name: Package plugin
       id: "package-plugin"
-      uses: grafana/plugin-actions/package-plugin@fix/signed-commits-build-plugin # zizmor: ignore[unpinned-uses]
+      uses: grafana/plugin-actions/package-plugin@main # zizmor: ignore[unpinned-uses]
       with:
         policy_token: ${{ inputs.policy_token }}
         sign_root_urls: ${{ inputs.sign_root_urls }}
         node-version: "${{ inputs.node-version }}"
         go-version: "${{ inputs.go-version }}"
         backend-target: "${{ inputs.backend-target }}"
-        skip_plugin_validator: "${{ inputs.skip_plugin_validator }}"
 
     - name: Get plugin metadata
       id: metadata

--- a/build-plugin/action.yml
+++ b/build-plugin/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
     required: false
     default: "false"
+  skip_plugin_validator:
+    description: "Skip the plugin validation step"
+    required: false
+    default: "false"
   use_changelog_generator:
     description: "Whether to generate a changelog for the plugin"
     required: false
@@ -75,6 +79,7 @@ runs:
         node-version: "${{ inputs.node-version }}"
         go-version: "${{ inputs.go-version }}"
         backend-target: "${{ inputs.backend-target }}"
+        skip_plugin_validator: "${{ inputs.skip_plugin_validator }}"
 
     - name: Get plugin metadata
       id: metadata

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -152,6 +152,7 @@ runs:
         PLUGIN_ARCHIVE_SHA1SUM: ${{ steps.metadata.outputs.archive-sha1sum }}
 
     - name: Validate plugin
+      continue-on-error: true
       run: |
         npx -y @grafana/plugin-validator@latest -sourceCodeUri file://./ $PLUGIN_ARCHIVE
       shell: bash

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
+  skip_plugin_validator:
+    description: "Skip the plugin validation step"
+    required: false
+    default: "false"
   backend-target:
     type: choice
     description: "Backend target for the plugin backend build"
@@ -152,7 +156,7 @@ runs:
         PLUGIN_ARCHIVE_SHA1SUM: ${{ steps.metadata.outputs.archive-sha1sum }}
 
     - name: Validate plugin
-      continue-on-error: true
+      if: ${{ inputs.skip_plugin_validator != 'true' }}
       run: |
         npx -y @grafana/plugin-validator@latest -sourceCodeUri file://./ $PLUGIN_ARCHIVE
       shell: bash

--- a/package-plugin/action.yml
+++ b/package-plugin/action.yml
@@ -32,10 +32,6 @@ inputs:
     description: "Version of node"
     required: false
     default: "20"
-  skip_plugin_validator:
-    description: "Skip the plugin validation step"
-    required: false
-    default: "false"
   backend-target:
     type: choice
     description: "Backend target for the plugin backend build"
@@ -156,7 +152,6 @@ runs:
         PLUGIN_ARCHIVE_SHA1SUM: ${{ steps.metadata.outputs.archive-sha1sum }}
 
     - name: Validate plugin
-      if: ${{ inputs.skip_plugin_validator != 'true' }}
       run: |
         npx -y @grafana/plugin-validator@latest -sourceCodeUri file://./ $PLUGIN_ARCHIVE
       shell: bash


### PR DESCRIPTION
Replaces the local `git commit` + `git push` in the changelog step with a `createCommitOnBranch` GraphQL API call.

Part of #240.

Test run: https://github.com/academo/academo-test-panel/actions/runs/27203399062
Verified commit: https://github.com/academo/academo-test-panel/commit/74b6f1628e234975aa238c2f5ebf7ab52510d418