### PR TITLE
fix(bundle-types): migrate to GATB and use GitHub API for signed commits

### DIFF
--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -110,22 +110,56 @@ runs:
       env:
         ENTRY_POINT: ${{ inputs.entry-point }}
 
-    - name: Create branch
+    - name: Create branch and commit via API
       if: ${{ steps.check-diff.outputs.has-changes == 'true' }}
       run: |
         cd ../plugin-extension-types
-        git config --local user.name grafana-plugins-platform-bot[bot]
-        git config --local user.email 144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com
 
-        git checkout -b $PLUGIN_ID-$PLUGIN_VERSION
-        git add .
-        git commit -m "types: updating $PLUGIN_ID"
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/plugin-extension-types $PLUGIN_ID-$PLUGIN_VERSION
+        BRANCH_NAME="${PLUGIN_ID}-${PLUGIN_VERSION}"
+        MAIN_SHA=$(gh api repos/grafana/plugin-extension-types/branches/main --jq '.commit.sha')
+
+        gh api repos/grafana/plugin-extension-types/git/refs \
+          -X POST \
+          -f "ref=refs/heads/${BRANCH_NAME}" \
+          -f "sha=${MAIN_SHA}"
+
+        ADDITIONS="[]"
+        DELETIONS="[]"
+
+        while IFS= read -r line; do
+          STATUS="${line:0:2}"
+          FILE="${line:3}"
+          if [[ "$STATUS" == "??" || "$STATUS" == " M" || "$STATUS" == "MM" ]]; then
+            CONTENTS=$(base64 -w 0 "$FILE")
+            ADDITIONS=$(echo "$ADDITIONS" | jq --arg path "$FILE" --arg contents "$CONTENTS" '. + [{path: $path, contents: $contents}]')
+          elif [[ "$STATUS" == " D" ]]; then
+            DELETIONS=$(echo "$DELETIONS" | jq --arg path "$FILE" '. + [{path: $path}]')
+          fi
+        done < <(git status --porcelain)
+
+        jq -n \
+          --arg repo "grafana/plugin-extension-types" \
+          --arg branch "$BRANCH_NAME" \
+          --arg message "types: updating ${PLUGIN_ID}" \
+          --arg headOid "$MAIN_SHA" \
+          --argjson additions "$ADDITIONS" \
+          --argjson deletions "$DELETIONS" \
+          '{
+            query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }",
+            variables: {
+              input: {
+                branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                message: { headline: $message },
+                fileChanges: { additions: $additions, deletions: $deletions },
+                expectedHeadOid: $headOid
+              }
+            }
+          }' | gh api graphql --input -
       shell: bash
       env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
         PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
-        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
     - name: Create or Update PR
       if: ${{ steps.check-diff.outputs.has-changes == 'true' }}

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Check OIDC token availability
       run: |
         if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
-          echo "::error::This action requires 'id-token: write' permission and GATB to be configured. See the bundle-types README for setup instructions."
+          echo "::error::This action requires 'id-token: write' permission and GATB to be configured. See https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#bundle-types-plugin-actions for setup instructions."
           exit 1
         fi
 

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -80,7 +80,7 @@ runs:
       run: |
         cd ..
         gh auth status
-        gh repo clone grafana/plugin-extension-types
+        gh repo clone grafana/plugin-extension-types -- --depth=1
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -114,12 +114,14 @@ runs:
         cd ../plugin-extension-types
 
         BRANCH_NAME="${PLUGIN_ID}-${PLUGIN_VERSION}"
-        MAIN_SHA=$(gh api repos/grafana/plugin-extension-types/branches/main --jq '.commit.sha')
+        BASE_SHA=$(git rev-parse HEAD)
 
-        gh api repos/grafana/plugin-extension-types/git/refs \
-          -X POST \
-          -f "ref=refs/heads/${BRANCH_NAME}" \
-          -f "sha=${MAIN_SHA}"
+        if ! gh api repos/grafana/plugin-extension-types/branches/${BRANCH_NAME} --silent 2>/dev/null; then
+          gh api repos/grafana/plugin-extension-types/git/refs \
+            -X POST \
+            -f "ref=refs/heads/${BRANCH_NAME}" \
+            -f "sha=${BASE_SHA}"
+        fi
 
         ADDITIONS="[]"
         DELETIONS="[]"
@@ -133,13 +135,13 @@ runs:
           elif [[ "$STATUS" == " D" ]]; then
             DELETIONS=$(echo "$DELETIONS" | jq --arg path "$FILE" '. + [{path: $path}]')
           fi
-        done < <(git status --porcelain)
+        done < <(git status --porcelain -uall)
 
         jq -n \
           --arg repo "grafana/plugin-extension-types" \
           --arg branch "$BRANCH_NAME" \
           --arg message "types: updating ${PLUGIN_ID}" \
-          --arg headOid "$MAIN_SHA" \
+          --arg headOid "$BASE_SHA" \
           --argjson additions "$ADDITIONS" \
           --argjson deletions "$DELETIONS" \
           '{

--- a/bundle-types/action.yml
+++ b/bundle-types/action.yml
@@ -38,6 +38,15 @@ runs:
         exit 1
       shell: bash
 
+    - name: Check OIDC token availability
+      run: |
+        if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+          echo "::error::This action requires 'id-token: write' permission and GATB to be configured. See the bundle-types README for setup instructions."
+          exit 1
+        fi
+
+      shell: bash
+
     - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version: "${{ inputs.node-version }}"
@@ -58,23 +67,12 @@ runs:
         PLUGIN_JSON_PATH: ${{ inputs.plugin-json-path }}
         PACKAGE_JSON_PATH: ${{ inputs.package-json-path }}
 
-    - id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
-      with:
-        common_secrets: |
-          GITHUB_APP_ID=plugins-platform-bot-app:app-id
-          GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-        export_env: false
-
     - name: Generate token
       id: generate-token
-      uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
       with:
-        app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-        private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-        owner: grafana
-        repositories: |
-            plugin-extension-types
+        github_app: grafana-plugins-platform-bot
+        permission_set: bundle-types
 
 
 


### PR DESCRIPTION
Migrates token generation to GATB. Also switches to `createCommitOnBranch` for signed commits (part of #240).

Consumers need to update their setup - see https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/035-github-app-permissions/#bundle-types-plugin-actions