### PR TITLE
feat(e2e-version): add feature-toggle-variants.json

### DIFF
--- a/e2e-version/feature-toggle-variants.json
+++ b/e2e-version/feature-toggle-variants.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "grafana-enterprise",
+    "enabledToggles": "react19",
+    "grafanaDependency": ">=13.1.0 <13.2.0",
+    "runInRepositories": ["^grafana/"]
+  }
+]


### PR DESCRIPTION
Adds the `feature-toggle-variants.json` file that the `e2e-version` action fetches at runtime from `main`.

This is split out from #239 so it can be merged first. Once it's on `main`, the runtime fetch in #239 resolves successfully, allowing that PR to be tested end-to-end.

The file is the single source of truth for feature-toggle variants — adding/removing entries later is a PR to `main` and applies to all consumers without an action release. See #239 for how the file is consumed and the field semantics.