### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "ignorePresets": [
+      "github>grafana/grafana-renovate-config//presets/base",
+      "github>grafana/grafana-renovate-config//presets/automerge",
+      "github>grafana/grafana-renovate-config//presets/labels",
+      "github>grafana/grafana-renovate-config//presets/npm"
+    ],
     "extends": [
-      "github>grafana/grafana-community-team//renovate/renovate"
-    ]    
+      "github>grafana/grafana-catalog-team//renovate/renovate"
+    ]
   }


### PR DESCRIPTION
Point the Renovate config at the renamed team preset (grafana-community-team was renamed to grafana-catalog-team) so this repo keeps tracking the shared config. Also added the four team-standard ignorePresets entries (base, automerge, labels, npm), which the repo did not have before. ignorePresets is not inherited from extended presets (renovatebot/renovate#14818), so it has to live in this file rather than the shared preset.

Part of grafana/grafana-catalog-team#1052.