### PR TITLE
feat (is-compatible): use plugin's min Grafana version as compatibility baseline

### DIFF
--- a/is-compatible/action.yml
+++ b/is-compatible/action.yml
@@ -28,10 +28,33 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
+    - id: min-version
+      run: |
+        # Read the plugin's declared minimum Grafana version from plugin.json (next to module.ts)
+        # so levitate can check compatibility across the whole supported range (min -> target).
+        PLUGIN_JSON="$(dirname "$LEVITATE_PATH")/plugin.json"
+        MIN_VERSION=""
+        if [[ -f "$PLUGIN_JSON" ]]; then
+          GRAFANA_DEP=$(jq -r '.dependencies.grafanaDependency // ""' "$PLUGIN_JSON")
+          # grafanaDependency looks like ">=10.0.0" or ">=10.0.0 <11.0.0"; take the first version.
+          MIN_VERSION=$(echo "$GRAFANA_DEP" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [[ -n "$MIN_VERSION" ]]; then
+            echo "Detected minimum Grafana version: $MIN_VERSION (from $PLUGIN_JSON)"
+          fi
+        fi
+        echo "value=$MIN_VERSION" >> "$GITHUB_OUTPUT"
+      shell: "bash"
+      env:
+        LEVITATE_PATH: ${{ inputs.module }}
     - id: run-levitate
       run: |
         # RUN levitate is-compatible. Save the output to .levitate_output
-        npx --yes @grafana/levitate@latest is-compatible --path $LEVITATE_PATH --target $LEVITATE_TARGETS --markdown | tee .levitate_output || true
+        # Use the detected minimum version as the baseline when available.
+        MIN_ARG=""
+        if [[ -n "$LEVITATE_MIN_VERSION" ]]; then
+          MIN_ARG="--min-package-version $LEVITATE_MIN_VERSION"
+        fi
+        npx --yes @grafana/levitate@latest is-compatible --path $LEVITATE_PATH --target $LEVITATE_TARGETS $MIN_ARG --markdown | tee .levitate_output || true
         # Detect the exit code based on the levitate output
         CODE=$(if [[ -n $(cat .levitate_output | grep "not fully compatible") ]]; then echo 1; else echo 0; fi)
         # Capture levitate output in an ENV variable
@@ -46,6 +69,7 @@ runs:
       env:
         LEVITATE_PATH: ${{ inputs.module }}
         LEVITATE_TARGETS: ${{ inputs.targets }}
+        LEVITATE_MIN_VERSION: ${{ steps.min-version.outputs.value }}
 
     # find the current PR (if running in one)
     - uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # v1.3.3


### PR DESCRIPTION
The `is-compatible` action now reads the plugin's declared minimum Grafana version from `plugin.json` (`dependencies.grafanaDependency`) and passes it to levitate via `--min-package-version`. Levitate then uses it as the baseline for the compatibility check.

- Backward-compatible: if there is no `plugin.json` or no `grafanaDependency`, the argument is omitted and behavior is unchanged.
- Requires the `--min-package-version` flag from levitate (https://github.com/grafana/levitate/pull/1044), which must be released first.