### PR TITLE
ci(renovate-approve): label needs-human verdicts for filtering

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -270,10 +270,21 @@ jobs:
                 body="${verdict#VERDICT: approve}"
                 gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "${body# }"
               fi
+              # A rebase can turn an earlier needs-human into an approve; drop
+              # the stale label so the filter only shows PRs still waiting.
+              gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label needs-manual-review 2>/dev/null || true
               ;;
             "VERDICT: needs-human"*)
               body="${verdict#VERDICT: needs-human}"
               gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
                 --body "$(printf 'Needs human review: %s\n\n<!-- renovate-approve: judged %s -->' "${body# }" "$HEAD_SHA")"
+              # Label for filtering (e.g. org-wide `gh search prs --label needs-manual-review`).
+              # Best-effort: a label failure must not fail the gate, the comment
+              # above is what marks the commit as judged.
+              gh label create needs-manual-review --repo "$GITHUB_REPOSITORY" --force \
+                --description "Renovate gate: Claude declined to auto-approve, a human must decide" \
+                --color D93F0B 2>/dev/null || true
+              gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label needs-manual-review ||
+                echo "Could not add the needs-manual-review label; continuing."
               ;;
           esac


### PR DESCRIPTION
When the Claude gate declines a Renovate PR it only leaves a comment, so finding all PRs waiting on a person means reading comments. Now the needs-human verdict also adds a `needs-manual-review` label (created on the fly if missing), and an approve verdict after a rebase removes it again. Labeling is best effort, a label failure never blocks the gate decision itself.

With this you can sweep everything waiting on a human across repos with `gh search prs --owner grafana --label needs-manual-review --state open`.

Same change should roll out to the other repos running this workflow once the pattern looks right here.